### PR TITLE
feat(affectation): gestion des statuts membre + statut RETARD #85

### DIFF
--- a/backend/src/conf/db/seed/seed_referential.py
+++ b/backend/src/conf/db/seed/seed_referential.py
@@ -72,7 +72,7 @@ class SeedReferentials:
             for c in ["BROUILLON", "PUBLIE", "ANNULE", "TERMINE"]:
                 self.get_or_create_upsert(StatutPlanning, {"code": c}, {})
 
-            for c in ["PROPOSE", "CONFIRME", "REFUSE", "PRESENT", "ABSENT"]:
+            for c in ["PROPOSE", "CONFIRME", "REFUSE", "PRESENT", "ABSENT", "RETARD"]:
                 self.get_or_create_upsert(StatutAffectation, {"code": c}, {})
 
             for c in ["RESPONSABLE", "ADJOINT", "MEMBRE_ACTIF"]:

--- a/backend/src/core/message.py
+++ b/backend/src/core/message.py
@@ -130,6 +130,16 @@ class ErrorRegistry:
         message="Le membre ne possède pas le rôle requis : {role}.",
         http_status=status.HTTP_400_BAD_REQUEST,
     )
+    AFFECTATION_TRANSITION_FORBIDDEN = ErrorDetail(
+        code="ASGN_007",
+        message="Transition de statut non autorisée pour ce rôle.",
+        http_status=status.HTTP_403_FORBIDDEN,
+    )
+    AFFECTATION_NOT_OWNER = ErrorDetail(
+        code="ASGN_008",
+        message="Vous n'êtes pas le membre concerné par cette affectation.",
+        http_status=status.HTTP_403_FORBIDDEN,
+    )
 
     # --- DOMAINE WORKFLOW (WKFL) ---
     WORKFLOW_INVALID_TRANSITION = ErrorDetail(

--- a/backend/src/core/workflow_engine.py
+++ b/backend/src/core/workflow_engine.py
@@ -103,7 +103,7 @@ planning_transitions: dict[PlanningStatusCode, list[PlanningStatusCode]] = {
     PlanningStatusCode.TERMINE: [],
 }
 
-# Affectation : PROPOSE, CONFIRME, REFUSE, PRESENT, ABSENT
+# Affectation : PROPOSE, CONFIRME, REFUSE, PRESENT, ABSENT, RETARD
 affectation_transitions: Dict[AffectationStatusCode, List[AffectationStatusCode]] = {
     AffectationStatusCode.PROPOSE: [
         AffectationStatusCode.CONFIRME,
@@ -112,9 +112,11 @@ affectation_transitions: Dict[AffectationStatusCode, List[AffectationStatusCode]
     AffectationStatusCode.CONFIRME: [
         AffectationStatusCode.PRESENT,
         AffectationStatusCode.ABSENT,
+        AffectationStatusCode.RETARD,
         AffectationStatusCode.REFUSE,
     ],
     AffectationStatusCode.REFUSE: [AffectationStatusCode.PROPOSE],
     AffectationStatusCode.PRESENT: [AffectationStatusCode.CONFIRME],
     AffectationStatusCode.ABSENT: [AffectationStatusCode.CONFIRME],
+    AffectationStatusCode.RETARD: [AffectationStatusCode.CONFIRME],
 }

--- a/backend/src/mla_enum/custom_enum.py
+++ b/backend/src/mla_enum/custom_enum.py
@@ -37,6 +37,7 @@ class AffectationStatusCode(str, Enum):
     REFUSE = "REFUSE"
     PRESENT = "PRESENT"
     ABSENT = "ABSENT"
+    RETARD = "RETARD"
 
 
 __all__ = [

--- a/backend/src/models/affectation_model.py
+++ b/backend/src/models/affectation_model.py
@@ -1,5 +1,7 @@
+from datetime import datetime
 from typing import Optional
 
+from pydantic import BaseModel, model_validator
 from sqlmodel import Field, SQLModel
 
 
@@ -28,9 +30,44 @@ class AffectationRead(AffectationBase):
     id: str
 
 
+class AffectationMemberRead(BaseModel):
+    """Vue enrichie d'une affectation pour un membre (page mes-affectations)."""
+
+    id: str
+    statut_affectation_code: str
+    role_code: str
+    slot_nom: str
+    slot_debut: datetime
+    slot_fin: datetime
+    activite_type: Optional[str] = None
+    ministere_nom: Optional[str] = None
+    model_config = {"from_attributes": True}
+
+    @model_validator(mode="before")
+    @classmethod
+    def flatten_relations(cls, data: object) -> object:
+        if isinstance(data, dict):
+            return data
+        slot = getattr(data, "slot", None)
+        planning = getattr(slot, "planning", None) if slot else None
+        activite = getattr(planning, "activite", None) if planning else None
+        ministere = getattr(data, "ministere", None)
+        return {
+            "id": getattr(data, "id", None),
+            "statut_affectation_code": getattr(data, "statut_affectation_code", None),
+            "role_code": getattr(data, "role_code", None),
+            "slot_nom": getattr(slot, "nom_creneau", "") if slot else "",
+            "slot_debut": getattr(slot, "date_debut", None) if slot else None,
+            "slot_fin": getattr(slot, "date_fin", None) if slot else None,
+            "activite_type": getattr(activite, "type", None) if activite else None,
+            "ministere_nom": getattr(ministere, "nom", None) if ministere else None,
+        }
+
+
 __all__ = [
     "AffectationBase",
     "AffectationCreate",
+    "AffectationMemberRead",
     "AffectationRead",
     "AffectationUpdate",
 ]

--- a/backend/src/routes/__init__.py
+++ b/backend/src/routes/__init__.py
@@ -6,6 +6,7 @@ from core.auth.auth_route import router as auth_router
 from notification.notification_router import router as notification
 
 from .activite_router import router as activite  # Doit être après planning pour les FK
+from .affectation_router import me_router as affectation_me  # Routes /me — avant /{id}
 from .affectation_router import (
     router as affectation,  # Doit être après planning pour les FK
 )
@@ -43,6 +44,7 @@ router.include_router(indisponibilite)
 router.include_router(equipe)  # Doit être après membre et ministre pour les FK
 router.include_router(slot)  # Doit être après membre_role pour les FK
 router.include_router(planning)  # Doit être après slot pour les FK
+router.include_router(affectation_me)  # Routes /me — avant /{id} pour éviter le conflit
 router.include_router(affectation)  # Doit être après planning pour les FK
 router.include_router(activite)  # Doit être après planning pour les FK
 router.include_router(profile)

--- a/backend/src/routes/affectation_router.py
+++ b/backend/src/routes/affectation_router.py
@@ -1,16 +1,49 @@
-# src/routes/planning_routes.py
-from fastapi import Depends
+# src/routes/affectation_router.py
+from typing import List
+
+from fastapi import APIRouter, Depends
 from sqlmodel import Session
 
 from conf.db.database import Database
+from core.auth.auth_dependencies import RoleChecker, get_current_active_user
 from mla_enum.custom_enum import AffectationStatusCode
-from models import AffectationCreate, AffectationRead, AffectationUpdate
+from models import AffectationCreate, AffectationRead, AffectationUpdate, Utilisateur
+from models.affectation_model import AffectationMemberRead
 from routes.deps import STANDARD_ADMIN_ONLY_DEPS
 from services.affectation_service import AffectationService
 
 from .base_route_factory import CRUDRouterFactory
 
-# 2. Routes pour AFFECTATIONS
+# Routes spécifiques /me — doivent être déclarées AVANT le factory (qui a /{id})
+# pour éviter que FastAPI capture "/me" comme un item_id.
+me_router = APIRouter(prefix="/affectations", tags=["Affectations"])
+
+
+@me_router.get("/me", response_model=List[AffectationMemberRead])
+def get_my_affectations(
+    current_user: Utilisateur = Depends(get_current_active_user),
+    db: Session = Depends(Database.get_db_for_route),
+) -> List[AffectationMemberRead]:
+    """Retourne les affectations du membre connecté."""
+    if not current_user.membre_id:
+        return []
+    service = AffectationService(db)
+    return service.get_my_affectations(current_user.membre_id)
+
+
+@me_router.get("/me/pending-count", response_model=int)
+def get_pending_count(
+    current_user: Utilisateur = Depends(get_current_active_user),
+    db: Session = Depends(Database.get_db_for_route),
+) -> int:
+    """Nombre d'affectations en attente (PROPOSE) pour le membre connecté."""
+    if not current_user.membre_id:
+        return 0
+    service = AffectationService(db)
+    return service.get_pending_count(current_user.membre_id)
+
+
+# Factory CRUD — génère GET /, GET /all, GET /{id}, POST /, PATCH /{id}, DELETE /{id}
 factory = CRUDRouterFactory(
     service_class=AffectationService,
     create_schema=AffectationCreate,
@@ -23,23 +56,33 @@ factory = CRUDRouterFactory(
 
 router = factory.router
 
-
-# 3. Extension spécifique pour les validations métiers (Affectation)
-# @router.post("/confirm/{aff_id}", tags=["Affectations"])
-# def confirm_presence(aff_id: str, db: Session = Depends(Database.get_session)):
-#     svc = AffectationService(db)
-#     return svc.update(aff_id, {"presence_confirmee": True})
+admin_or_resp = Depends(RoleChecker(["ADMIN", "RESPONSABLE_MLA"]))
 
 
-# Router spécifique pour Affectation (logique de création surchargée)
+@router.patch("/{affectation_id}/my-status")
+def change_my_affectation_status(
+    affectation_id: str,
+    new_status: AffectationStatusCode,
+    current_user: Utilisateur = Depends(get_current_active_user),
+    db: Session = Depends(Database.get_db_for_route),
+):
+    """Accepte ou refuse une affectation (PROPOSE→CONFIRME/REFUSE, membre seul)."""
+    membre_id = current_user.membre_id or ""
+    service = AffectationService(db)
+    return service.update_my_affectation_status(
+        affectation_id, new_status, membre_id=membre_id
+    )
 
 
-@router.patch("/{affectation_id}/status")
+@router.patch(
+    "/{affectation_id}/status",
+    dependencies=[admin_or_resp],
+)
 def change_affectation_status(
     affectation_id: str,
     new_status: AffectationStatusCode,
     db: Session = Depends(Database.get_db_for_route),
 ):
-    """Change le statut d'une affectation (PROPOSE -> CONFIRME, etc.)."""
+    """Change le statut d'une affectation (Admin/Responsable)."""
     service = AffectationService(db)
     return service.update_affectation_status(affectation_id, new_status)

--- a/backend/src/services/affectation_service.py
+++ b/backend/src/services/affectation_service.py
@@ -8,6 +8,7 @@ from core.message import ErrorRegistry
 from core.workflow_engine import WorkflowEngine, affectation_transitions
 from mla_enum.custom_enum import AffectationStatusCode, PlanningStatusCode
 from models import Affectation, PlanningService, Slot
+from models.affectation_model import AffectationMemberRead
 from repositories.planning_repository import PlanningRepository
 from services.validation_engine import ValidationEngine
 
@@ -34,7 +35,7 @@ class AffectationService:
     def _validate_pointing_status(self, planning: Optional[PlanningService]):
         """
         Mutualisation de la règle métier :
-        Le pointage (PRESENT/ABSENT) requiert un planning publié.
+        Le pointage (PRESENT/ABSENT/RETARD) requiert un planning publié.
         """
         if not planning:
             raise AppException(ErrorRegistry.Affectation_PLANNING_NOT_FOUND)
@@ -59,6 +60,7 @@ class AffectationService:
         if final_status in [
             AffectationStatusCode.PRESENT,
             AffectationStatusCode.ABSENT,
+            AffectationStatusCode.RETARD,
         ]:
             slot = self.db.get(Slot, slot_id)
             if not slot:
@@ -85,7 +87,12 @@ class AffectationService:
             raise AppException(ErrorRegistry.Affectation_NOT_FOUND)
 
         # Règle métier croisée : Pointage possible uniquement si planning PUBLIE
-        if new_status in [AffectationStatusCode.PRESENT, AffectationStatusCode.ABSENT]:
+        pointing = [
+            AffectationStatusCode.PRESENT,
+            AffectationStatusCode.ABSENT,
+            AffectationStatusCode.RETARD,
+        ]
+        if new_status in pointing:
             planning = self.db.get(PlanningService, affectation.slot.planning_id)
             # Utilisation de la méthode de validation mutualisée
             if not planning:
@@ -99,6 +106,50 @@ class AffectationService:
         self.db.add(affectation)
         self.db.flush()
         return affectation
+
+    def update_my_affectation_status(
+        self,
+        affectation_id: str,
+        new_status: AffectationStatusCode,
+        *,
+        membre_id: str,
+    ) -> Affectation:
+        """Transition autorisée uniquement par le membre (PROPOSE→CONFIRME/REFUSE)."""
+        affectation = self.db.get(Affectation, affectation_id)
+        if not affectation or not affectation.slot:
+            raise AppException(ErrorRegistry.Affectation_NOT_FOUND)
+
+        if affectation.membre_id != membre_id:
+            raise AppException(ErrorRegistry.AFFECTATION_NOT_OWNER)
+
+        allowed_for_member = [
+            AffectationStatusCode.CONFIRME,
+            AffectationStatusCode.REFUSE,
+        ]
+        if new_status not in allowed_for_member:
+            raise AppException(ErrorRegistry.AFFECTATION_TRANSITION_FORBIDDEN)
+
+        current_status = AffectationStatusCode(affectation.statut_affectation_code)
+        self.workflow.validate_transition(current_status, new_status)
+
+        affectation.statut_affectation_code = new_status.value
+        self.db.add(affectation)
+        self.db.flush()
+        return affectation
+
+    def get_my_affectations(self, membre_id: str) -> List[AffectationMemberRead]:
+        """Retourne les affectations enrichies du membre connecté."""
+        stmt = select(Affectation).where(Affectation.membre_id == membre_id)
+        affectations = self.db.exec(stmt).all()
+        return [AffectationMemberRead.model_validate(a) for a in affectations]
+
+    def get_pending_count(self, membre_id: str) -> int:
+        """Nombre d'affectations en statut PROPOSE pour le membre."""
+        stmt = select(Affectation).where(
+            Affectation.membre_id == membre_id,
+            Affectation.statut_affectation_code == AffectationStatusCode.PROPOSE.value,
+        )
+        return len(self.db.exec(stmt).all())
 
     def sync_affectations(self, slot_id: str, affectations_data: List[Any]):
         """Gère le delta (Add/Update/Delete) des affectations pour un slot."""

--- a/backend/src/tests/test_workflow_engine.py
+++ b/backend/src/tests/test_workflow_engine.py
@@ -96,6 +96,7 @@ def test_get_allowed_transitions_standard(affectation_wf):
     expected = [
         AffectationStatusCode.PRESENT,
         AffectationStatusCode.ABSENT,
+        AffectationStatusCode.RETARD,
         AffectationStatusCode.REFUSE,
     ]
     assert allowed == expected

--- a/frontend/layers/base/app/components/TopBar.vue
+++ b/frontend/layers/base/app/components/TopBar.vue
@@ -26,15 +26,18 @@
         <span class="hidden md:inline">Créer Planning</span>
       </button>
 
-      <button
+      <NuxtLink
+        to="/planning/mes-affectations"
         class="relative rounded-full p-2 text-slate-500 hover:bg-slate-50"
-        aria-label="Notifications"
+        aria-label="Mes affectations en attente"
       >
         <Bell class="size-5" />
         <span
-          class="absolute top-1.5 right-1.5 size-2 rounded-full border-2 border-white bg-red-500"
-        ></span>
-      </button>
+          v-if="pendingCount > 0"
+          class="absolute top-0.5 right-0.5 flex size-4 items-center justify-center rounded-full border border-white bg-red-500 text-[9px] font-bold text-white"
+          >{{ pendingCount > 9 ? '9+' : pendingCount }}</span
+        >
+      </NuxtLink>
     </div>
   </header>
 </template>
@@ -43,14 +46,19 @@
 import { computed, onMounted } from 'vue'
 import { ChevronRight, Plus, Menu, Bell } from 'lucide-vue-next'
 import { useUIStore } from '../stores/useUiStore'
+import { useMyAffectationsStore } from '~~/layers/planning/app/stores/useMyAffectationsStore'
 
 const ui = useUIStore()
+const myAffectationsStore = useMyAffectationsStore()
 const route = useRoute()
+
+const pendingCount = computed(() => myAffectationsStore.pendingCount)
 
 // Initialisation au montage du parent pour garantir la disponibilité des données
 onMounted(async () => {
   try {
     await ui.initializeUI()
+    await myAffectationsStore.refreshPendingCount()
   } catch {
     // silently ignore init errors
   }

--- a/frontend/layers/base/app/layouts/default.vue
+++ b/frontend/layers/base/app/layouts/default.vue
@@ -84,6 +84,14 @@
                   class="pl-9"
                 />
                 <SidebarLink
+                  to="/planning/mes-affectations"
+                  :icon="Bell"
+                  label="Mes affectations"
+                  :collapsed="false"
+                  :badge="pendingAffectationsCount || undefined"
+                  class="pl-9"
+                />
+                <SidebarLink
                   v-if="authStore.hasAdminAccess"
                   to="/planning/indisponibilites"
                   :icon="CalendarOff"
@@ -122,6 +130,14 @@
                       label="Liste des Plannings"
                       :collapsed="false"
                       :badge="planningStore.draftCount"
+                      @click="closePopup"
+                    />
+                    <SidebarLink
+                      to="/planning/mes-affectations"
+                      :icon="Bell"
+                      label="Mes affectations"
+                      :collapsed="false"
+                      :badge="pendingAffectationsCount || undefined"
                       @click="closePopup"
                     />
                     <SidebarLink
@@ -330,6 +346,7 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
 import {
+  Bell,
   Building2,
   CalendarDays,
   CalendarOff,
@@ -343,9 +360,11 @@ import {
 import { useUIStore } from '../stores/useUiStore'
 import { useAuthStore } from '~~/layers/auth/app/stores/useAuthStore'
 import { useSessionManager } from '~~/layers/auth/app/composables/useSessionManager'
+import { useMyAffectationsStore } from '~~/layers/planning/app/stores/useMyAffectationsStore'
 
 const ui = useUIStore()
 const authStore = useAuthStore()
+const myAffectationsStore = useMyAffectationsStore()
 useSessionManager()
 
 const isPlanningOpen = ref(true)
@@ -353,6 +372,8 @@ const isPopupVisible = ref(false)
 const triggerRef = ref<HTMLElement | null>(null)
 const popupTop = ref(0)
 const planningStore = { draftCount: 5 }
+
+const pendingAffectationsCount = computed(() => myAffectationsStore.pendingCount)
 
 let closeTimer: ReturnType<typeof setTimeout> | null = null
 

--- a/frontend/layers/planning/app/components/PlanningFormView.vue
+++ b/frontend/layers/planning/app/components/PlanningFormView.vue
@@ -355,6 +355,33 @@
                       {{ role.libelle }}
                     </option>
                   </select>
+                  <!-- Statut (lecture seule sauf planning PUBLIE) -->
+                  <span
+                    v-if="aff.statut_affectation_code && formTargetStatus !== 'PUBLIE'"
+                    class="shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-semibold"
+                    :class="{
+                      'bg-amber-100 text-amber-700': aff.statut_affectation_code === 'PROPOSE',
+                      'bg-emerald-100 text-emerald-700': aff.statut_affectation_code === 'CONFIRME',
+                      'bg-rose-100 text-rose-700': aff.statut_affectation_code === 'REFUSE',
+                      'bg-blue-100 text-blue-700': aff.statut_affectation_code === 'PRESENT',
+                      'bg-slate-100 text-slate-500': aff.statut_affectation_code === 'ABSENT',
+                      'bg-orange-100 text-orange-700': aff.statut_affectation_code === 'RETARD',
+                    }"
+                    >{{ aff.statut_affectation_code }}</span
+                  >
+                  <select
+                    v-if="aff.id && formTargetStatus === 'PUBLIE'"
+                    v-model="aff.statut_affectation_code"
+                    class="shrink-0 rounded-md border border-slate-200 bg-white px-1.5 py-1 text-[10px] text-slate-600 focus:border-blue-400 focus:outline-none"
+                    @change="handleStatusChange(aff.id!, aff.statut_affectation_code!)"
+                  >
+                    <option value="PROPOSE">En attente</option>
+                    <option value="CONFIRME">Confirmé</option>
+                    <option value="REFUSE">Refusé</option>
+                    <option value="PRESENT">Présent</option>
+                    <option value="ABSENT">Absent</option>
+                    <option value="RETARD">En retard</option>
+                  </select>
                   <button
                     type="button"
                     class="shrink-0 rounded-full p-1 text-slate-300 transition-colors hover:bg-red-50 hover:text-red-400"
@@ -540,7 +567,21 @@ import {
 import FormSection from '~~/layers/base/app/components/FormSection.vue'
 import { planningFormKey } from '../composables/usePlanningForm'
 import { ACTIVITE_TYPES } from '../types/planning.types'
+import type { AffectationStatus } from '../types/planning.types'
 import { useIndisponibiliteWarning } from '../composables/useIndisponibiliteWarning'
+import { AffectationRepository } from '../repositories/AffectationRepository'
+
+const affRepo = new AffectationRepository()
+const notify = useMLANotify()
+
+async function handleStatusChange(affId: string, newStatus: AffectationStatus) {
+  try {
+    await affRepo.updateStatus(affId, newStatus)
+    notify.success('Statut mis à jour')
+  } catch {
+    // handled by global fetch interceptor
+  }
+}
 
 // Destructurer pour bénéficier de l'auto-unwrap des refs dans le template
 const {
@@ -555,6 +596,7 @@ const {
   campusMinistereColorMap,
   isLoadingMinisteres,
   selectedMinistereColor,
+  formTargetStatus,
   toggleSection,
   selectMinistere,
   onDateDebutChange,

--- a/frontend/layers/planning/app/composables/usePlanningForm.ts
+++ b/frontend/layers/planning/app/composables/usePlanningForm.ts
@@ -11,6 +11,7 @@ import {
 } from 'vue'
 import { PlanningRepository } from '../repositories/PlanningRepository'
 import type {
+  AffectationStatus,
   ActiviteFormState,
   CampusTeamRead,
   MinistereColor,
@@ -447,6 +448,7 @@ export function usePlanningForm(
             membre_nom: a.membre!.nom,
             role_code: a.role_code,
             ministere_id: findMinistreForMembreInTeam(campusTeam.value, a.membre!.id),
+            statut_affectation_code: a.statut_affectation_code as AffectationStatus | undefined,
           })),
       }))
     } else {

--- a/frontend/layers/planning/app/pages/planning/mes-affectations.vue
+++ b/frontend/layers/planning/app/pages/planning/mes-affectations.vue
@@ -1,0 +1,175 @@
+<script setup lang="ts">
+import { computed, onMounted } from 'vue'
+import { Bell, CheckCircle2, XCircle, Clock } from 'lucide-vue-next'
+import { useMyAffectationsStore } from '../../stores/useMyAffectationsStore'
+import type { AffectationStatus } from '../../types/planning.types'
+
+definePageMeta({ layout: 'default' })
+
+const store = useMyAffectationsStore()
+
+onMounted(() => store.fetchMyAffectations())
+
+// --- GROUPES ---
+const pending = computed(() =>
+  store.affectations.filter((a) => a.statut_affectation_code === 'PROPOSE'),
+)
+const confirmed = computed(() =>
+  store.affectations.filter((a) => a.statut_affectation_code === 'CONFIRME'),
+)
+const others = computed(() =>
+  store.affectations.filter((a) =>
+    ['REFUSE', 'PRESENT', 'ABSENT', 'RETARD'].includes(a.statut_affectation_code),
+  ),
+)
+
+// --- HELPERS ---
+const STATUS_CONFIG: Record<AffectationStatus, { label: string; class: string }> = {
+  PROPOSE: { label: 'En attente', class: 'bg-amber-100 text-amber-700' },
+  CONFIRME: { label: 'Confirmé', class: 'bg-emerald-100 text-emerald-700' },
+  REFUSE: { label: 'Refusé', class: 'bg-rose-100 text-rose-700' },
+  PRESENT: { label: 'Présent', class: 'bg-blue-100 text-blue-700' },
+  ABSENT: { label: 'Absent', class: 'bg-slate-100 text-slate-500' },
+  RETARD: { label: 'En retard', class: 'bg-orange-100 text-orange-700' },
+}
+
+const formatDate = (iso: string) =>
+  new Date(iso).toLocaleDateString('fr-FR', {
+    weekday: 'short',
+    day: 'numeric',
+    month: 'short',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+</script>
+
+<template>
+  <div class="mx-auto flex w-full max-w-4xl flex-col gap-6 p-4 md:p-8">
+    <!-- En-tête -->
+    <div class="flex flex-col gap-1">
+      <div class="flex items-center gap-2">
+        <Bell class="text-primary-600 size-5" />
+        <h1 class="text-xl font-bold text-slate-800">Mes affectations</h1>
+      </div>
+      <p class="text-sm text-slate-500">Acceptez ou refusez les propositions d'affectation.</p>
+    </div>
+
+    <!-- Squelette -->
+    <div v-if="store.loading" class="flex flex-col gap-3">
+      <div v-for="n in 4" :key="n" class="h-20 animate-pulse rounded-xl bg-slate-100"></div>
+    </div>
+
+    <template v-else>
+      <!-- En attente -->
+      <section v-if="pending.length > 0">
+        <h2 class="mb-3 text-xs font-bold tracking-wider text-amber-600 uppercase">
+          En attente de réponse ({{ pending.length }})
+        </h2>
+        <ul class="flex flex-col gap-2">
+          <li
+            v-for="aff in pending"
+            :key="aff.id"
+            class="flex items-center justify-between gap-4 rounded-xl border border-amber-100 bg-amber-50 p-4"
+          >
+            <div class="min-w-0 flex-1">
+              <p class="truncate font-semibold text-slate-800">
+                {{ aff.activite_type ?? 'Activité' }}
+              </p>
+              <p class="mt-0.5 text-xs text-slate-500">
+                {{ aff.slot_nom }} · {{ formatDate(aff.slot_debut) }}
+              </p>
+              <p v-if="aff.ministere_nom" class="mt-0.5 text-xs text-slate-400">
+                {{ aff.ministere_nom }}
+              </p>
+            </div>
+            <div class="flex shrink-0 items-center gap-2">
+              <button
+                class="flex items-center gap-1 rounded-lg border border-rose-200 bg-white px-3 py-1.5 text-xs font-semibold text-rose-600 transition-colors hover:bg-rose-50"
+                @click="store.refuseAffectation(aff.id)"
+              >
+                <XCircle class="size-3.5" />
+                Refuser
+              </button>
+              <button
+                class="flex items-center gap-1 rounded-lg px-3 py-1.5 text-xs font-semibold text-white transition-all active:scale-95"
+                style="background-color: var(--color-primary-600)"
+                @click="store.acceptAffectation(aff.id)"
+              >
+                <CheckCircle2 class="size-3.5" />
+                Accepter
+              </button>
+            </div>
+          </li>
+        </ul>
+      </section>
+
+      <!-- Confirmées -->
+      <section v-if="confirmed.length > 0">
+        <h2 class="mb-3 text-xs font-bold tracking-wider text-emerald-600 uppercase">
+          Confirmées ({{ confirmed.length }})
+        </h2>
+        <ul class="flex flex-col gap-2">
+          <li
+            v-for="aff in confirmed"
+            :key="aff.id"
+            class="flex items-center gap-4 rounded-xl border border-slate-100 bg-white p-4"
+          >
+            <CheckCircle2 class="size-5 shrink-0 text-emerald-500" />
+            <div class="min-w-0 flex-1">
+              <p class="truncate font-semibold text-slate-800">
+                {{ aff.activite_type ?? 'Activité' }}
+              </p>
+              <p class="mt-0.5 text-xs text-slate-500">
+                {{ aff.slot_nom }} · {{ formatDate(aff.slot_debut) }}
+              </p>
+            </div>
+            <span
+              class="rounded-full px-2 py-0.5 text-[11px] font-semibold"
+              :class="STATUS_CONFIG['CONFIRME'].class"
+            >
+              {{ STATUS_CONFIG['CONFIRME'].label }}
+            </span>
+          </li>
+        </ul>
+      </section>
+
+      <!-- Autres statuts -->
+      <section v-if="others.length > 0">
+        <h2 class="mb-3 text-xs font-bold tracking-wider text-slate-400 uppercase">
+          Historique ({{ others.length }})
+        </h2>
+        <ul class="flex flex-col gap-2">
+          <li
+            v-for="aff in others"
+            :key="aff.id"
+            class="flex items-center gap-4 rounded-xl border border-slate-100 bg-white p-4"
+          >
+            <Clock class="size-5 shrink-0 text-slate-400" />
+            <div class="min-w-0 flex-1">
+              <p class="truncate font-semibold text-slate-700">
+                {{ aff.activite_type ?? 'Activité' }}
+              </p>
+              <p class="mt-0.5 text-xs text-slate-500">
+                {{ aff.slot_nom }} · {{ formatDate(aff.slot_debut) }}
+              </p>
+            </div>
+            <span
+              class="rounded-full px-2 py-0.5 text-[11px] font-semibold"
+              :class="STATUS_CONFIG[aff.statut_affectation_code as AffectationStatus].class"
+            >
+              {{ STATUS_CONFIG[aff.statut_affectation_code as AffectationStatus].label }}
+            </span>
+          </li>
+        </ul>
+      </section>
+
+      <!-- Vide -->
+      <div
+        v-if="store.affectations.length === 0"
+        class="rounded-xl border border-slate-100 bg-slate-50 p-10 text-center text-sm text-slate-400"
+      >
+        Aucune affectation pour le moment.
+      </div>
+    </template>
+  </div>
+</template>

--- a/frontend/layers/planning/app/repositories/AffectationRepository.ts
+++ b/frontend/layers/planning/app/repositories/AffectationRepository.ts
@@ -1,0 +1,28 @@
+import { BaseRepository } from '~~/layers/base/app/repositories/BaseRepository'
+import type { AffectationMemberRead, AffectationStatus } from '../types/planning.types'
+
+export class AffectationRepository extends BaseRepository {
+  async getMyAffectations(): Promise<AffectationMemberRead[]> {
+    const { data } = await this.apiRequest<AffectationMemberRead[]>('/affectations/me')
+    return data as unknown as AffectationMemberRead[]
+  }
+
+  async getPendingCount(): Promise<number> {
+    const { data } = await this.apiRequest<number>('/affectations/me/pending-count')
+    return data as unknown as number
+  }
+
+  async updateMyStatus(affectationId: string, newStatus: AffectationStatus): Promise<void> {
+    await this.apiRequest(`/affectations/${affectationId}/my-status`, {
+      method: 'PATCH',
+      query: { new_status: newStatus },
+    })
+  }
+
+  async updateStatus(affectationId: string, newStatus: AffectationStatus): Promise<void> {
+    await this.apiRequest(`/affectations/${affectationId}/status`, {
+      method: 'PATCH',
+      query: { new_status: newStatus },
+    })
+  }
+}

--- a/frontend/layers/planning/app/stores/useMyAffectationsStore.ts
+++ b/frontend/layers/planning/app/stores/useMyAffectationsStore.ts
@@ -1,0 +1,56 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { AffectationRepository } from '../repositories/AffectationRepository'
+import type { AffectationMemberRead, AffectationStatus } from '../types/planning.types'
+
+export const useMyAffectationsStore = defineStore('myAffectations', () => {
+  const repo = new AffectationRepository()
+  const notify = useMLANotify()
+
+  const affectations = ref<AffectationMemberRead[]>([])
+  const pendingCount = ref(0)
+  const loading = ref(false)
+
+  async function fetchMyAffectations() {
+    loading.value = true
+    try {
+      affectations.value = await repo.getMyAffectations()
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function refreshPendingCount() {
+    pendingCount.value = await repo.getPendingCount()
+  }
+
+  async function acceptAffectation(id: string) {
+    await repo.updateMyStatus(id, 'CONFIRME')
+    notify.success('Affectation acceptée')
+    await fetchMyAffectations()
+    await refreshPendingCount()
+  }
+
+  async function refuseAffectation(id: string) {
+    await repo.updateMyStatus(id, 'REFUSE')
+    notify.info('Affectation refusée')
+    await fetchMyAffectations()
+    await refreshPendingCount()
+  }
+
+  async function updateStatus(id: string, status: AffectationStatus) {
+    await repo.updateStatus(id, status)
+    notify.success('Statut mis à jour')
+  }
+
+  return {
+    affectations,
+    pendingCount,
+    loading,
+    fetchMyAffectations,
+    refreshPendingCount,
+    acceptAffectation,
+    refuseAffectation,
+    updateStatus,
+  }
+})

--- a/frontend/layers/planning/app/types/planning.types.ts
+++ b/frontend/layers/planning/app/types/planning.types.ts
@@ -45,6 +45,9 @@ export function getMinistereColor(ministereId: string, allMinistereIds: string[]
 /** Correspond aux valeurs de l'enum PlanningStatusCode côté backend */
 export type PlanningStatus = 'BROUILLON' | 'PUBLIE' | 'ANNULE' | 'TERMINE'
 
+/** Correspond aux valeurs de l'enum AffectationStatusCode côté backend */
+export type AffectationStatus = 'PROPOSE' | 'CONFIRME' | 'REFUSE' | 'PRESENT' | 'ABSENT' | 'RETARD'
+
 export type PlanningViewPerspective = 'PERSONAL' | 'MINISTERE' | 'CAMPUS'
 
 // ============================================================
@@ -116,6 +119,19 @@ export interface ActiviteUpdate {
   description?: string
   campus_id?: string
   ministere_organisateur_id?: string
+}
+
+// --- Vue membre de ses propres affectations ---
+
+export interface AffectationMemberRead {
+  id: string
+  statut_affectation_code: AffectationStatus
+  role_code: string
+  slot_nom: string
+  slot_debut: string
+  slot_fin: string
+  activite_type?: string | null
+  ministere_nom?: string | null
 }
 
 // --- Membre résumé (dans les affectations) ---
@@ -269,6 +285,7 @@ export interface AffectationFormItem {
   membre_nom: string
   role_code: string
   ministere_id: string
+  statut_affectation_code?: AffectationStatus
 }
 
 /** Slot dans le formulaire */


### PR DESCRIPTION
Backend:
- Ajoute AffectationStatusCode.RETARD à l'enum et au seed referential
- Met à jour les transitions workflow : CONFIRME→RETARD et RETARD→CONFIRME
- Ajoute AFFECTATION_TRANSITION_FORBIDDEN (ASGN_007) et AFFECTATION_NOT_OWNER (ASGN_008)
- Ajoute AffectationMemberRead (schéma enrichi avec slot/activité/ministère)
- Ajoute get_my_affectations(), get_pending_count(), update_my_affectation_status()
- Sépare me_router (GET /me, GET /me/pending-count) du factory router pour éviter la collision avec GET /{item_id} — me_router inclus en premier dans routes/__init__
- Sécurise PATCH /{id}/status (Admin/Responsable) et PATCH /{id}/my-status (membre)
- Met à jour test_workflow_engine pour inclure RETARD dans les transitions CONFIRME

Frontend:
- Ajoute AffectationStatus union type et AffectationMemberRead interface
- Ajoute statut_affectation_code dans AffectationFormItem et usePlanningForm (initForm)
- Crée AffectationRepository (getMyAffectations, getPendingCount, updateMyStatus, updateStatus)
- Crée useMyAffectationsStore (accept/refuse/refresh)
- TopBar : badge dynamique sur la cloche affichant le nombre de PROPOSE
- default.vue : lien "Mes affectations" dans la sidebar avec badge pending
- Nouvelle page /planning/mes-affectations : liste des affectations groupées (en attente avec boutons Accept/Refus, confirmées, historique)
- PlanningFormView : badge de statut par affectation + select de pointage pour les plannings PUBLIE (appel API immédiat sur changement)