### PR TITLE
feat(songbook): accès admin global, champ artiste, lien YouTube et lecteur intégré #102

### DIFF
--- a/backend/alembic/versions/54f4e7390542_merge_template_and_youtube_heads.py
+++ b/backend/alembic/versions/54f4e7390542_merge_template_and_youtube_heads.py
@@ -1,0 +1,28 @@
+"""merge_template_and_youtube_heads
+
+Revision ID: 54f4e7390542
+Revises: 6dbf6e801432, e1f2a3b4c5d6
+Create Date: 2026-03-21 23:22:13.295231
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '54f4e7390542'
+down_revision: Union[str, Sequence[str], None] = ('6dbf6e801432', 'e1f2a3b4c5d6')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass

--- a/backend/alembic/versions/e1f2a3b4c5d6_add_youtube_url_to_chant.py
+++ b/backend/alembic/versions/e1f2a3b4c5d6_add_youtube_url_to_chant.py
@@ -1,0 +1,27 @@
+"""add youtube_url to t_chant
+
+Revision ID: e1f2a3b4c5d6
+Revises: d0e1f2a3b4c5
+Create Date: 2026-03-21 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "e1f2a3b4c5d6"
+down_revision: Union[str, Sequence[str], None] = "d0e1f2a3b4c5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "t_chant",
+        sa.Column("youtube_url", sa.String(500), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("t_chant", "youtube_url")

--- a/backend/src/conf/db/seed/data.py
+++ b/backend/src/conf/db/seed/data.py
@@ -365,6 +365,7 @@ class ChantSeedData(TypedDict):
     categorie_code: str
     tonalite: str
     paroles_chords: str
+    youtube_url: Optional[str]
 
 
 SONGBOOK_CATEGORIES: List[ChantCategorieData] = [
@@ -381,6 +382,7 @@ SONGBOOK_CHANTS: List[ChantSeedData] = [
         "artiste": "ICC Worship",
         "categorie_code": "LOUANGE",
         "tonalite": "D",
+        "youtube_url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
         "paroles_chords": (
             "[D]Tu es ma sour-[A]ce, ma [Bm]force,\n"
             "[G]Tu es ma [D]vie. [A]\n"
@@ -398,6 +400,7 @@ SONGBOOK_CHANTS: List[ChantSeedData] = [
         "artiste": "ICC Worship",
         "categorie_code": "LOUANGE",
         "tonalite": "C",
+        "youtube_url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
         "paroles_chords": (
             "[C]Je louerai l'É-[G]ternel de [Am]tout mon cœur,\n"
             "[F]Je raconterai [C]toutes tes [G]merveilles.\n"
@@ -415,6 +418,7 @@ SONGBOOK_CHANTS: List[ChantSeedData] = [
         "artiste": "Hillsong FR",
         "categorie_code": "CONTEMPORAIN",
         "tonalite": "E",
+        "youtube_url": None,
         "paroles_chords": (
             "[E]Tu mérites tout l'hon-[B]neur,\n"
             "[C#m]Tout l'honneur qui t'appar-[A]tient,\n"
@@ -432,6 +436,7 @@ SONGBOOK_CHANTS: List[ChantSeedData] = [
         "artiste": "Hillsong FR",
         "categorie_code": "CONTEMPORAIN",
         "tonalite": "A",
+        "youtube_url": None,
         "paroles_chords": (
             "[A]Tu as été [E]percé pour [F#m]moi,\n"
             "[D]Tu as porté [A]ma [E]honte.\n"
@@ -448,6 +453,7 @@ SONGBOOK_CHANTS: List[ChantSeedData] = [
         "artiste": "Gospel Chorale",
         "categorie_code": "GOSPEL",
         "tonalite": "F",
+        "youtube_url": None,
         "paroles_chords": (
             "[F]Al-lé-lu-[Bb]ia, al-lé-lu-[C]ia,\n"
             "[F]Al-lé-lu-[Bb]ia, al-lé-lu-[C]ia. [F]\n"
@@ -463,6 +469,7 @@ SONGBOOK_CHANTS: List[ChantSeedData] = [
         "artiste": "Traditionnel",
         "categorie_code": "CANTIQUES",
         "tonalite": "G",
+        "youtube_url": None,
         "paroles_chords": (
             "[G]Saint, [D]Saint, [Em]Saint !"
             " [C]Seigneur [G]Dieu [D]tout-puis-[G]sant !\n"
@@ -479,6 +486,7 @@ SONGBOOK_CHANTS: List[ChantSeedData] = [
         "artiste": "Traditionnel",
         "categorie_code": "TRADITIONNEL",
         "tonalite": "G",
+        "youtube_url": None,
         "paroles_chords": (
             "[G]Quelle [C]grâce éton-[G]nante !\n"
             "[G]Quelle [D]merveille à mes [G]yeux !\n"
@@ -496,6 +504,7 @@ SONGBOOK_CHANTS: List[ChantSeedData] = [
         "artiste": "ICC Worship",
         "categorie_code": "LOUANGE",
         "tonalite": "Bb",
+        "youtube_url": None,
         "paroles_chords": (
             "[Bb]Tu es [F]Dieu, tu es [Gm]Roi,\n"
             "[Eb]Tu règnes sur [Bb]tout. [F]\n"

--- a/backend/src/conf/db/seed/seed_service.py
+++ b/backend/src/conf/db/seed/seed_service.py
@@ -877,6 +877,7 @@ class SeedService:
                 defaults={
                     "artiste": data["artiste"],
                     "categorie_code": data["categorie_code"],
+                    "youtube_url": data["youtube_url"],
                     "actif": True,
                 },
             )

--- a/backend/src/core/message.py
+++ b/backend/src/core/message.py
@@ -580,3 +580,8 @@ class ErrorRegistry:
         message="Les demi-tons doivent être compris entre -12 et 12.",
         http_status=status.HTTP_422_UNPROCESSABLE_ENTITY,
     )
+    SONG_008 = ErrorDetail(
+        code="SONG_008",
+        message="campus_id obligatoire pour ce rôle",
+        http_status=status.HTTP_422_UNPROCESSABLE_ENTITY,
+    )

--- a/backend/src/models/chant_model.py
+++ b/backend/src/models/chant_model.py
@@ -9,13 +9,20 @@ Tables créées :
   t_chant_tag        — étiquettes libres
 """
 
+import re
 import uuid
 from datetime import datetime, timezone
 from typing import List, Optional
 
-from pydantic import ConfigDict
+from pydantic import ConfigDict, field_validator
 from sqlalchemy import Column, Text
 from sqlmodel import Field, Relationship, SQLModel
+
+_YOUTUBE_RE = re.compile(
+    r"^https?://(?:www\.|m\.)?(?:youtube\.com/"
+    r"(?:watch\?[^&]*v=|embed/|shorts/)|youtu\.be/)"
+    r"[A-Za-z0-9_-]{11}"
+)
 
 # -------------------------
 # BASE MODELS
@@ -42,6 +49,7 @@ class ChantBase(SQLModel):
         ondelete="SET NULL",
     )
     actif: bool = Field(default=True)
+    youtube_url: Optional[str] = Field(default=None, max_length=500)
 
 
 class ChantContenuBase(SQLModel):
@@ -179,6 +187,7 @@ class ChantRead(SQLModel):
     categorie_code: Optional[str]
     actif: bool
     date_creation: datetime
+    youtube_url: Optional[str] = None
 
 
 class ChantCreate(SQLModel):
@@ -188,6 +197,18 @@ class ChantCreate(SQLModel):
     artiste: Optional[str] = Field(default=None, max_length=150)
     campus_id: str
     categorie_code: Optional[str] = None
+    youtube_url: Optional[str] = None
+
+    @field_validator("youtube_url")
+    @classmethod
+    def validate_youtube_url(cls, v: Optional[str]) -> Optional[str]:
+        """Valide que l'URL est bien une URL YouTube reconnue."""
+        if v is None:
+            return None
+        stripped = v.strip()
+        if not _YOUTUBE_RE.match(stripped):
+            raise ValueError("URL YouTube invalide")
+        return stripped
 
 
 class ChantUpdate(SQLModel):
@@ -196,6 +217,18 @@ class ChantUpdate(SQLModel):
     titre: Optional[str] = None
     artiste: Optional[str] = None
     categorie_code: Optional[str] = None
+    youtube_url: Optional[str] = None
+
+    @field_validator("youtube_url")
+    @classmethod
+    def validate_youtube_url(cls, v: Optional[str]) -> Optional[str]:
+        """Valide que l'URL est bien une URL YouTube reconnue."""
+        if v is None:
+            return None
+        stripped = v.strip()
+        if not _YOUTUBE_RE.match(stripped):
+            raise ValueError("URL YouTube invalide")
+        return stripped
 
 
 class ChantContenuRead(SQLModel):

--- a/backend/src/routes/chant_router.py
+++ b/backend/src/routes/chant_router.py
@@ -10,7 +10,11 @@ from fastapi import APIRouter, Depends, Query, status
 from sqlmodel import Session
 
 from conf.db.database import Database
-from core.auth.auth_dependencies import RoleChecker
+from core.auth.auth_dependencies import RoleChecker, get_current_active_user
+from core.exceptions.app_exception import AppException
+from core.message import ErrorRegistry
+from mla_enum import RoleName
+from models import Utilisateur
 from models.base_pagination import PaginatedResponse
 from models.chant_model import (
     ChantCategorieCreate,
@@ -111,22 +115,33 @@ def delete_categorie(
 # ------------------------------------------------------------------ #
 
 
+_ADMIN_ROLES = {RoleName.SUPER_ADMIN, RoleName.ADMIN}
+
+
 @router.get(
     "",
     response_model=PaginatedResponse[ChantRead],
     status_code=status.HTTP_200_OK,
     summary="Lister les chants (paginé, multi-tenant)",
-    dependencies=[_AUTH],
 )
 def list_chants(  # pylint: disable=too-many-positional-arguments
-    campus_id: str = Query(..., description="Filtre multi-tenant obligatoire"),
+    campus_id: Optional[str] = Query(None, description="Filtre multi-tenant"),
     categorie_code: Optional[str] = Query(None),
     artiste: Optional[str] = Query(None),
     q: Optional[str] = Query(None, description="Recherche sur le titre"),
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
     svc: ChantService = Depends(_get_svc),
+    current_user: Utilisateur = Depends(get_current_active_user),
 ) -> PaginatedResponse[ChantRead]:
+    if campus_id is None:
+        user_roles = {
+            aff.role.libelle
+            for aff in current_user.affectations
+            if aff.role and aff.role.libelle is not None
+        }
+        if not user_roles.intersection(_ADMIN_ROLES):
+            raise AppException(ErrorRegistry.SONG_008)
     items, total = svc.list_chants(
         campus_id=campus_id,
         categorie_code=categorie_code,

--- a/backend/src/services/chant_service.py
+++ b/backend/src/services/chant_service.py
@@ -201,7 +201,7 @@ class ChantService:
     def list_chants(
         self,
         *,
-        campus_id: str,
+        campus_id: Optional[str] = None,
         categorie_code: Optional[str] = None,
         artiste: Optional[str] = None,
         q: Optional[str] = None,
@@ -210,10 +210,11 @@ class ChantService:
     ) -> Tuple[List[ChantRead], int]:
         """Liste paginée des chants — filtrée par campus (multi-tenant)."""
         stmt = select(Chant).where(
-            Chant.campus_id == campus_id,
             Chant.deleted_at == None,  # noqa: E711
             Chant.actif == True,  # noqa: E712
         )
+        if campus_id is not None:
+            stmt = stmt.where(Chant.campus_id == campus_id)
         if categorie_code:
             stmt = stmt.where(Chant.categorie_code == categorie_code)
         # pylint: disable=no-member
@@ -248,6 +249,7 @@ class ChantService:
             artiste=payload.artiste,
             campus_id=payload.campus_id,
             categorie_code=payload.categorie_code,
+            youtube_url=payload.youtube_url,
         )
         self.db.add(chant)
         self.db.flush()
@@ -263,6 +265,8 @@ class ChantService:
             chant.artiste = payload.artiste
         if payload.categorie_code is not None:
             chant.categorie_code = payload.categorie_code
+        if payload.youtube_url is not None:
+            chant.youtube_url = payload.youtube_url
         self.db.add(chant)
         self.db.flush()
         self.db.refresh(chant)

--- a/backend/src/tests/test_chant.py
+++ b/backend/src/tests/test_chant.py
@@ -10,6 +10,7 @@ Fixtures utilisées :
 from uuid import uuid4
 
 import pytest
+from fastapi.testclient import TestClient
 from sqlmodel import Session
 
 from core.exceptions.app_exception import AppException
@@ -405,3 +406,79 @@ def test_transpose_does_not_save(
     reloaded = chant_svc.get_contenu(str(test_chant.id))
     assert reloaded.version == version_before
     assert reloaded.tonalite == "G"
+
+
+# ------------------------------------------------------------------ #
+#  US1 — Accès admin sans campus_id
+# ------------------------------------------------------------------ #
+
+
+def test_list_chants_superadmin_no_campus_id(
+    client: TestClient,
+    superadmin_headers: dict,
+    test_chant: Chant,
+) -> None:
+    """Super Admin obtient 200 sans campus_id."""
+    response = client.get("/chants", headers=superadmin_headers)
+    assert response.status_code == 200
+    body = response.json()
+    assert "data" in body
+
+
+def test_list_chants_non_admin_requires_campus_id(
+    client: TestClient,
+    user_headers: dict,
+) -> None:
+    """Un membre sans campus_id reçoit 422 (SONG_008)."""
+    response = client.get("/chants", headers=user_headers)
+    assert response.status_code == 422
+
+
+# ------------------------------------------------------------------ #
+#  US2 — YouTube URL
+# ------------------------------------------------------------------ #
+
+
+def test_create_chant_with_valid_youtube_url(
+    chant_svc: ChantService,
+    test_campus: Campus,
+) -> None:
+    """Création avec youtube_url valide persiste l'URL."""
+    url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    payload = ChantCreate(
+        titre="Chant YouTube Test",
+        campus_id=str(test_campus.id),
+        youtube_url=url,
+    )
+    read = chant_svc.create_chant(payload)
+    assert read.youtube_url == url
+
+
+def test_create_chant_with_invalid_youtube_url(
+    chant_svc: ChantService,
+    test_campus: Campus,
+) -> None:
+    """URL non-YouTube lève une ValueError de validation Pydantic."""
+    with pytest.raises(Exception):
+        ChantCreate(
+            titre="Chant URL Invalide",
+            campus_id=str(test_campus.id),
+            youtube_url="https://vimeo.com/123456789ab",
+        )
+
+
+def test_chant_full_returns_youtube_url(
+    chant_svc: ChantService,
+    session: Session,
+    test_campus: Campus,
+) -> None:
+    """get_chant_full retourne le champ youtube_url."""
+    url = "https://youtu.be/dQw4w9WgXcQ"
+    payload = ChantCreate(
+        titre="Chant Full YouTube",
+        campus_id=str(test_campus.id),
+        youtube_url=url,
+    )
+    created = chant_svc.create_chant(payload)
+    full = chant_svc.get_chant_full(created.id)
+    assert full.youtube_url == url

--- a/frontend/layers/songbook/app/components/YoutubePlayerModal.vue
+++ b/frontend/layers/songbook/app/components/YoutubePlayerModal.vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+import { X } from 'lucide-vue-next'
+
+const props = defineProps<{
+  youtubeUrl: string
+}>()
+
+const emit = defineEmits<{
+  close: []
+}>()
+
+/**
+ * Extrait le videoId depuis les formats YouTube connus :
+ *   youtu.be/ID, watch?v=ID, /embed/ID, /shorts/ID
+ */
+const videoId = computed<string | null>(() => {
+  try {
+    const url = new URL(props.youtubeUrl)
+    if (url.hostname === 'youtu.be') {
+      return url.pathname.slice(1).split('?')[0] ?? null
+    }
+    const v = url.searchParams.get('v')
+    if (v) return v
+    const segments = url.pathname.split('/')
+    const idx = segments.findIndex((s) => s === 'embed' || s === 'shorts')
+    if (idx !== -1) return segments[idx + 1] ?? null
+  } catch {
+    // URL invalide
+  }
+  return null
+})
+
+const embedSrc = computed(() =>
+  videoId.value ? `https://www.youtube-nocookie.com/embed/${videoId.value}?autoplay=1&rel=0` : null,
+)
+
+function onBackdropClick(e: MouseEvent) {
+  if (e.target === e.currentTarget) emit('close')
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      class="fixed inset-0 flex items-center justify-center bg-black/70"
+      style="z-index: 20000"
+      @click="onBackdropClick"
+    >
+      <div class="relative w-full max-w-3xl px-4">
+        <!-- Bouton fermer -->
+        <button
+          type="button"
+          class="absolute -top-10 right-4 flex items-center gap-1.5 rounded-lg bg-white/10 px-3 py-1.5 text-sm text-white hover:bg-white/20"
+          @click="emit('close')"
+        >
+          <X class="h-4 w-4" />
+          Fermer
+        </button>
+
+        <!-- Lecteur -->
+        <div v-if="embedSrc" class="aspect-video w-full overflow-hidden rounded-2xl">
+          <iframe
+            :src="embedSrc"
+            class="h-full w-full"
+            allow="autoplay; encrypted-media"
+            allowfullscreen
+            sandbox="allow-scripts allow-same-origin allow-presentation allow-popups"
+            title="Lecteur YouTube"
+          />
+        </div>
+
+        <div
+          v-else
+          class="flex aspect-video w-full items-center justify-center rounded-2xl bg-black text-sm text-white"
+        >
+          Impossible d'extraire l'identifiant vidéo.
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/frontend/layers/songbook/app/composables/useSongbook.ts
+++ b/frontend/layers/songbook/app/composables/useSongbook.ts
@@ -56,13 +56,13 @@ export const useSongbook = () => {
   }
 
   async function loadChants(
-    campusId: string,
+    campusId?: string,
     opts: { q?: string; categorie?: string } = {},
   ): Promise<void> {
     isLoading.value = true
     try {
       const result: PaginatedChants = await repo.listChants({
-        campus_id: campusId,
+        campus_id: campusId || undefined,
         q: opts.q,
         categorie_code: opts.categorie,
         limit: 100,

--- a/frontend/layers/songbook/app/pages/songbook/[id]/edit.vue
+++ b/frontend/layers/songbook/app/pages/songbook/[id]/edit.vue
@@ -47,6 +47,7 @@ const form = reactive({
   titre: '',
   artiste: '',
   categorie_code: '',
+  youtube_url: '',
   tonalite: '',
   paroles_chords: '',
 })
@@ -67,6 +68,7 @@ watch(
     form.titre = chant.titre
     form.artiste = chant.artiste ?? ''
     form.categorie_code = chant.categorie_code ?? ''
+    form.youtube_url = chant.youtube_url ?? ''
     form.tonalite = chant.contenu?.tonalite ?? ''
     form.paroles_chords = chant.contenu?.paroles_chords ?? ''
     // Sync preview immédiat
@@ -82,6 +84,7 @@ const isDirty = computed(
     form.titre !== (selectedChant.value?.titre ?? '') ||
     form.artiste !== (selectedChant.value?.artiste ?? '') ||
     form.categorie_code !== (selectedChant.value?.categorie_code ?? '') ||
+    form.youtube_url !== (selectedChant.value?.youtube_url ?? '') ||
     form.paroles_chords !== (selectedChant.value?.contenu?.paroles_chords ?? '') ||
     form.tonalite !== (selectedChant.value?.contenu?.tonalite ?? ''),
 )
@@ -118,6 +121,7 @@ async function handleSave(contenu: ChantContenuCreate) {
     titre: form.titre.trim(),
     artiste: form.artiste.trim() || undefined,
     categorie_code: form.categorie_code || undefined,
+    youtube_url: form.youtube_url.trim() || undefined,
   })
   const existing = selectedChant.value?.contenu
   if (existing) {
@@ -245,6 +249,17 @@ onMounted(async () => {
                 Catégorie
               </label>
               <ChantCategorieSelect v-model="form.categorie_code" :categories="categories" />
+            </div>
+            <div class="sm:col-span-2">
+              <label class="mb-1 block text-sm font-medium text-(--color-neutral-700)">
+                Lien YouTube
+              </label>
+              <input
+                v-model="form.youtube_url"
+                type="url"
+                placeholder="https://www.youtube.com/watch?v=…"
+                class="w-full rounded-lg border border-(--color-neutral-300) px-3 py-2 text-sm focus:border-(--color-primary-400) focus:outline-none"
+              />
             </div>
           </div>
 

--- a/frontend/layers/songbook/app/pages/songbook/[id]/index.vue
+++ b/frontend/layers/songbook/app/pages/songbook/[id]/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ArrowLeft, Music2, AlignLeft, Pencil, ChevronRight } from 'lucide-vue-next'
+import { ArrowLeft, Music2, AlignLeft, Pencil, ChevronRight, Youtube } from 'lucide-vue-next'
 import { useAuthStore } from '~~/layers/auth/app/stores/useAuthStore'
 import { useUIStore } from '~~/layers/base/app/stores/useUiStore'
 import type { ChantTransposeResponse } from '../../../types/chant'
@@ -26,6 +26,9 @@ const {
   loadCategories,
   loadChants,
 } = useSongbook()
+
+// ── Lecteur YouTube ────────────────────────────────────────────────────────
+const showYoutubePlayer = ref(false)
 
 // ── Toggle accords/paroles ─────────────────────────────────────────────────
 const showChords = ref(true)
@@ -183,6 +186,40 @@ onMounted(async () => {
         </div>
       </div>
 
+      <!-- ── Lecteur YouTube ──────────────────────────────────────────── -->
+      <div
+        v-if="selectedChant.youtube_url"
+        class="flex items-center gap-3 rounded-2xl border border-(--color-red-100) bg-(--color-red-50) px-5 py-4"
+      >
+        <Youtube class="h-5 w-5 shrink-0 text-(--color-red-500)" />
+        <span class="flex-1 text-sm font-medium text-(--color-red-700)">
+          Une vidéo YouTube est disponible pour ce chant
+        </span>
+        <button
+          type="button"
+          class="inline-flex items-center gap-1.5 rounded-lg bg-(--color-red-600) px-4 py-2 text-sm font-medium text-white hover:bg-(--color-red-700)"
+          @click="showYoutubePlayer = true"
+        >
+          <Youtube class="h-4 w-4" />
+          Regarder
+        </button>
+      </div>
+      <div
+        v-else-if="authStore.canManageChants"
+        class="flex items-center gap-3 rounded-2xl border border-(--color-neutral-200) bg-(--color-neutral-50) px-5 py-4"
+      >
+        <Youtube class="h-5 w-5 shrink-0 text-(--color-neutral-400)" />
+        <span class="flex-1 text-sm text-(--color-neutral-500)"
+          >Aucun lien YouTube pour ce chant</span
+        >
+        <NuxtLink
+          :to="`/songbook/${id}/edit`"
+          class="text-sm text-(--color-primary-600) hover:text-(--color-primary-700) hover:underline"
+        >
+          Ajouter
+        </NuxtLink>
+      </div>
+
       <!-- Contrôle transposition (accords uniquement) -->
       <ChantTransposeControl
         v-if="showChords && selectedChant.contenu"
@@ -215,5 +252,12 @@ onMounted(async () => {
         </template>
       </div>
     </div>
+
+    <!-- Lecteur YouTube intégré (Teleport to body) -->
+    <YoutubePlayerModal
+      v-if="showYoutubePlayer && selectedChant?.youtube_url"
+      :youtubeUrl="selectedChant.youtube_url"
+      @close="showYoutubePlayer = false"
+    />
   </div>
 </template>

--- a/frontend/layers/songbook/app/pages/songbook/new.vue
+++ b/frontend/layers/songbook/app/pages/songbook/new.vue
@@ -28,6 +28,7 @@ const form = reactive({
   titre: '',
   artiste: '',
   categorie_code: '',
+  youtube_url: '',
   tonalite: '',
   paroles_chords: '',
 })
@@ -74,6 +75,7 @@ async function handleSave(contenu: ChantContenuCreate) {
     artiste: form.artiste.trim() || undefined,
     campus_id: campusId.value,
     categorie_code: form.categorie_code || undefined,
+    youtube_url: form.youtube_url.trim() || undefined,
   })
   if (created && contenu.paroles_chords.trim()) {
     await upsertContenu(created.id, {
@@ -157,6 +159,17 @@ onMounted(() => {
                 Catégorie
               </label>
               <ChantCategorieSelect v-model="form.categorie_code" :categories="categories" />
+            </div>
+            <div class="sm:col-span-2">
+              <label class="mb-1 block text-sm font-medium text-(--color-neutral-700)">
+                Lien YouTube
+              </label>
+              <input
+                v-model="form.youtube_url"
+                type="url"
+                placeholder="https://www.youtube.com/watch?v=…"
+                class="w-full rounded-lg border border-(--color-neutral-300) px-3 py-2 text-sm focus:border-(--color-primary-400) focus:outline-none"
+              />
             </div>
           </div>
 

--- a/frontend/layers/songbook/app/repositories/ChantRepository.ts
+++ b/frontend/layers/songbook/app/repositories/ChantRepository.ts
@@ -49,7 +49,8 @@ export class ChantRepository extends BaseRepository {
   // ---- Chants ----
 
   async listChants(params: ChantListParams): Promise<PaginatedChants> {
-    const query = new URLSearchParams({ campus_id: params.campus_id })
+    const query = new URLSearchParams()
+    if (params.campus_id) query.set('campus_id', params.campus_id)
     if (params.categorie_code) query.set('categorie_code', params.categorie_code)
     if (params.artiste) query.set('artiste', params.artiste)
     if (params.q) query.set('q', params.q)

--- a/frontend/layers/songbook/app/types/chant.ts
+++ b/frontend/layers/songbook/app/types/chant.ts
@@ -18,12 +18,14 @@ export interface ChantCreate {
   artiste?: string
   campus_id: string
   categorie_code?: string
+  youtube_url?: string | null
 }
 
 export interface ChantUpdate {
   titre?: string
   artiste?: string
   categorie_code?: string
+  youtube_url?: string | null
 }
 
 export interface ChantContenuCreate {
@@ -58,6 +60,7 @@ export interface ChantRead {
   categorie_code?: string
   actif: boolean
   date_creation: string
+  youtube_url?: string | null
 }
 
 export interface ChantContenuRead {
@@ -81,7 +84,7 @@ export interface ChantTransposeResponse {
 }
 
 export interface ChantListParams {
-  campus_id: string
+  campus_id?: string
   categorie_code?: string
   artiste?: string
   q?: string


### PR DESCRIPTION

- Admins (Super Admin + Admin) accèdent à tous les chants sans filtre campus_id
- Ajout du champ youtube_url sur Chant (modèle, schémas, validator regex)
- Migration Alembic : colonne youtube_url sur t_chant + merge des têtes
- Formulaires création/édition : champ URL YouTube avec validation côté front
- Page détail : bandeau YouTube visible avec bouton "Regarder" (lecteur intégré)
- YoutubePlayerModal : iframe sandboxée, extraction videoId, Teleport to body
- Tests : admin sans campus_id (200), non-admin sans campus_id (422), URL YouTube valide/invalide, présence youtube_url dans la réponse