### PR TITLE
feat(planning): membres suggérés dans les templates + validation compétence + scroll fade (#96)

### DIFF
--- a/backend/alembic/versions/f15f3d7ac637_add_template_role_membres.py
+++ b/backend/alembic/versions/f15f3d7ac637_add_template_role_membres.py
@@ -1,0 +1,46 @@
+"""add_template_role_membres
+
+Revision ID: f15f3d7ac637
+Revises: 54f4e7390542
+Create Date: 2026-03-23 23:59:45.923750
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = 'f15f3d7ac637'
+down_revision: Union[str, Sequence[str], None] = '54f4e7390542'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Crée t_planning_template_role_membre si elle n'existe pas encore."""
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    if 't_planning_template_role_membre' not in inspector.get_table_names():
+        op.create_table(
+            't_planning_template_role_membre',
+            sa.Column('id', sa.String(), nullable=False),
+            sa.Column('template_role_id', sa.String(), nullable=False),
+            sa.Column('membre_id', sa.String(), nullable=False),
+            sa.ForeignKeyConstraint(
+                ['membre_id'],
+                ['t_membre.id'],
+                ondelete='CASCADE',
+            ),
+            sa.ForeignKeyConstraint(
+                ['template_role_id'],
+                ['t_planningtemplaterole.id'],
+                ondelete='CASCADE',
+            ),
+            sa.PrimaryKeyConstraint('id'),
+        )
+
+
+def downgrade() -> None:
+    """Supprime t_planning_template_role_membre."""
+    op.drop_table('t_planning_template_role_membre')

--- a/backend/src/conf/db/seed/data.py
+++ b/backend/src/conf/db/seed/data.py
@@ -29,12 +29,17 @@ class OrganisationData(TypedDict):
     date_creation: datetime
 
 
+class PlanningTemplateRoleSeedData(TypedDict):
+    role_code: str
+    membres_suggeres_ids: List[str]
+
+
 class PlanningTemplateSlotSeedData(TypedDict):
     nom_creneau: str
     offset_debut_minutes: int
     offset_fin_minutes: int
     nb_personnes_requis: int
-    roles: List[str]
+    roles: List[PlanningTemplateRoleSeedData]
 
 
 class PlanningTemplateSeedData(TypedDict):
@@ -51,7 +56,7 @@ PLANNING_TEMPLATES_SEED: List[PlanningTemplateSeedData] = [
     {
         "nom": "Culte Dominical Standard",
         "description": (
-            "Template type pour un culte dominical " "avec louange matin et soir."
+            "Template type pour un culte dominical" " avec louange matin et soir."
         ),
         "activite_type": "Culte Dominical",
         "duree_minutes": 720,
@@ -62,14 +67,32 @@ PLANNING_TEMPLATES_SEED: List[PlanningTemplateSeedData] = [
                 "offset_debut_minutes": 0,
                 "offset_fin_minutes": 180,
                 "nb_personnes_requis": 2,
-                "roles": ["TENOR", "SON"],
+                "roles": [
+                    {
+                        "role_code": "TENOR",
+                        "membres_suggeres_ids": [],
+                    },
+                    {
+                        "role_code": "SON",
+                        "membres_suggeres_ids": [],
+                    },
+                ],
             },
             {
                 "nom_creneau": "Équipe Louange Soir",
                 "offset_debut_minutes": 540,
                 "offset_fin_minutes": 720,
                 "nb_personnes_requis": 2,
-                "roles": ["TENOR", "SON"],
+                "roles": [
+                    {
+                        "role_code": "TENOR",
+                        "membres_suggeres_ids": [],
+                    },
+                    {
+                        "role_code": "SON",
+                        "membres_suggeres_ids": [],
+                    },
+                ],
             },
         ],
     },
@@ -85,7 +108,12 @@ PLANNING_TEMPLATES_SEED: List[PlanningTemplateSeedData] = [
                 "offset_debut_minutes": 0,
                 "offset_fin_minutes": 60,
                 "nb_personnes_requis": 3,
-                "roles": ["HOTE_ACCUEIL"],
+                "roles": [
+                    {
+                        "role_code": "HOTE_ACCUEIL",
+                        "membres_suggeres_ids": [],
+                    },
+                ],
             },
         ],
     },

--- a/backend/src/conf/db/seed/seed_service.py
+++ b/backend/src/conf/db/seed/seed_service.py
@@ -33,6 +33,7 @@ from models import (
     PlanningService,
     PlanningTemplate,
     PlanningTemplateRole,
+    PlanningTemplateRoleMembre,
     PlanningTemplateSlot,
     Pole,
     Responsabilite,
@@ -841,12 +842,27 @@ class SeedService:
                     "nb_personnes_requis": s["nb_personnes_requis"],
                 },
             )
-            for role_code in s["roles"]:
-                self._get_or_create(
+            for role_data in s["roles"]:
+                role, _ = self._get_or_create(
                     PlanningTemplateRole,
                     slot_id=slot.id,
-                    role_code=role_code,
+                    role_code=role_data["role_code"],
                 )
+                self._seed_template_role_membres(
+                    role.id,
+                    role_data.get("membres_suggeres_ids", []),
+                )
+
+    def _seed_template_role_membres(self, role_id: str, membre_ids: list) -> None:
+        """Crée les membres suggérés d'un rôle de template (idempotent)."""
+        for membre_id in membre_ids:
+            if self.db.get(Membre, membre_id) is None:
+                continue
+            self._get_or_create(
+                PlanningTemplateRoleMembre,
+                template_role_id=role_id,
+                membre_id=membre_id,
+            )
 
     # --- SONGBOOK ---
 

--- a/backend/src/models/membre_model.py
+++ b/backend/src/models/membre_model.py
@@ -71,6 +71,14 @@ class MembreSimple(MembreBase):
     model_config = {"from_attributes": True}
 
 
+class MembreSimpleWithRoles(MembreSimple):
+    """MembreSimple enrichi des role_codes de compétence."""
+
+    roles: List[str] = Field(default_factory=list)
+
+    model_config = {"from_attributes": True}
+
+
 # -------------------------
 # READ (Version Allégée - Utilisée partout en imbriqué)
 # -------------------------
@@ -163,5 +171,6 @@ __all__ = [
     "UtilisateurSimple",
     "MembreRoleSimple",
     "MembreSimple",
+    "MembreSimpleWithRoles",
     "MembreRoleRich",
 ]

--- a/backend/src/models/planning_template_model.py
+++ b/backend/src/models/planning_template_model.py
@@ -4,6 +4,16 @@ from datetime import datetime
 from typing import List, Optional
 
 from pydantic import BaseModel, Field, field_validator
+from typing_extensions import TypedDict
+
+
+class PlanningTemplateRoleMembreRead(BaseModel):
+    """DTO lecture d'un membre suggéré pour un rôle de template."""
+
+    id: str
+    membre_id: str
+    membre_nom: str
+    membre_username: str
 
 
 class PlanningTemplateRoleRead(BaseModel):
@@ -11,6 +21,14 @@ class PlanningTemplateRoleRead(BaseModel):
 
     id: str
     role_code: str
+    membres_suggeres: List[PlanningTemplateRoleMembreRead] = Field(default_factory=list)
+
+
+class PlanningTemplateRoleWrite(BaseModel):
+    """Payload création/remplacement d'un rôle de template."""
+
+    role_code: str
+    membres_suggeres_ids: List[str] = Field(default_factory=list)
 
 
 class PlanningTemplateSlotRead(BaseModel):
@@ -66,7 +84,7 @@ class PlanningTemplateSlotWrite(BaseModel):
     offset_debut_minutes: int = Field(ge=0)
     offset_fin_minutes: int = Field(ge=1)
     nb_personnes_requis: int = Field(default=1, ge=1)
-    roles: List[str]  # liste de role_codes
+    roles: List[PlanningTemplateRoleWrite]
 
 
 class PlanningTemplateFullUpdate(BaseModel):
@@ -97,3 +115,45 @@ class PlanningTemplateUpdate(BaseModel):
 
     nom: Optional[str] = Field(default=None, min_length=1, max_length=150)
     description: Optional[str] = Field(default=None, max_length=500)
+
+
+# ── TypedDict résultats apply US-96 ───────────────────────────────────────────
+
+
+class WarningIndispo(TypedDict):
+    """Avertissement : membre indisponible à la date du planning."""
+
+    membre_id: str
+    membre_nom: str
+    creneau_nom: str
+    role_code: str
+
+
+class WarningMembreIgnore(TypedDict):
+    """Avertissement : membre ignoré lors de l'application."""
+
+    membre_id: str
+    membre_nom: str
+    role_code: str
+    raison: str  # "hors_ministere" | "introuvable"
+
+
+class ApplyTemplateResult(TypedDict):
+    """Résultat de l'application d'un template sur un planning."""
+
+    planning_id: str
+    affectations_creees: int
+    avertissements_indispo: List[WarningIndispo]
+    membres_ignores: List[WarningMembreIgnore]
+
+
+# ── Schéma Pydantic pour le response_model FastAPI ────────────────────────────
+
+
+class ApplyTemplateResultSchema(BaseModel):
+    """Schéma Pydantic miroir de ApplyTemplateResult (pour response_model)."""
+
+    planning_id: str
+    affectations_creees: int
+    avertissements_indispo: List[WarningIndispo]
+    membres_ignores: List[WarningMembreIgnore]

--- a/backend/src/models/schema_db_model.py
+++ b/backend/src/models/schema_db_model.py
@@ -502,6 +502,30 @@ class PlanningTemplateRole(SQLModel, table=True):  # type: ignore
     role_code: str = Field(max_length=50)
 
     slot: Optional["PlanningTemplateSlot"] = Relationship(back_populates="roles")
+    membres_suggeres: List["PlanningTemplateRoleMembre"] = Relationship(
+        back_populates="template_role",
+        sa_relationship_kwargs={"cascade": "all, delete-orphan"},
+    )
+
+
+class PlanningTemplateRoleMembre(SQLModel, table=True):  # type: ignore
+    __tablename__ = "t_planning_template_role_membre"
+    __table_args__ = {"extend_existing": True}
+
+    id: str = Field(default_factory=lambda: str(uuid4()), primary_key=True)
+    template_role_id: str = Field(
+        foreign_key="t_planningtemplaterole.id",
+        ondelete="CASCADE",
+    )
+    membre_id: str = Field(
+        foreign_key="t_membre.id",
+        ondelete="CASCADE",
+    )
+
+    template_role: Optional["PlanningTemplateRole"] = Relationship(
+        back_populates="membres_suggeres"
+    )
+    membre: Optional["Membre"] = Relationship()
 
 
 __all__ = [
@@ -546,4 +570,5 @@ __all__ = [
     "PlanningTemplate",
     "PlanningTemplateSlot",
     "PlanningTemplateRole",
+    "PlanningTemplateRoleMembre",
 ]

--- a/backend/src/repositories/planning_template_repository.py
+++ b/backend/src/repositories/planning_template_repository.py
@@ -6,7 +6,12 @@ from sqlalchemy import desc
 from sqlalchemy.orm import selectinload
 from sqlmodel import Session, col, select
 
-from models.schema_db_model import PlanningTemplate, PlanningTemplateSlot
+from models.schema_db_model import (
+    PlanningTemplate,
+    PlanningTemplateRole,
+    PlanningTemplateRoleMembre,
+    PlanningTemplateSlot,
+)
 from repositories.base_repository import BaseRepository
 
 
@@ -17,7 +22,7 @@ class PlanningTemplateRepository(BaseRepository[PlanningTemplate]):
         super().__init__(db, PlanningTemplate)
 
     def get_with_slots(self, template_id: str) -> Optional[PlanningTemplate]:
-        """Charge un template avec ses créneaux et rôles (évite N+1)."""
+        """Charge template avec créneaux, rôles et membres suggérés."""
         stmt = (
             select(PlanningTemplate)
             .where(PlanningTemplate.id == template_id)
@@ -28,11 +33,14 @@ class PlanningTemplateRepository(BaseRepository[PlanningTemplate]):
         return self.db.exec(stmt).first()
 
     def _slot_roles_option(self):  # type: ignore[return]
-        """Retourne l'option eager-load slots → roles."""
-        return selectinload(
-            PlanningTemplate.slots  # type: ignore[arg-type]
-        ).selectinload(
-            PlanningTemplateSlot.roles  # type: ignore[arg-type]
+        """Retourne l'option eager-load slots → roles → membres_suggeres → membre."""
+        return (
+            selectinload(PlanningTemplate.slots)  # type: ignore[arg-type]
+            .selectinload(PlanningTemplateSlot.roles)  # type: ignore[arg-type]
+            .selectinload(
+                PlanningTemplateRole.membres_suggeres  # type: ignore[arg-type]
+            )
+            .selectinload(PlanningTemplateRoleMembre.membre)  # type: ignore[arg-type]
         )
 
     def list_by_campus(self, campus_id: str) -> List[PlanningTemplate]:

--- a/backend/src/routes/membre_router.py
+++ b/backend/src/routes/membre_router.py
@@ -8,10 +8,10 @@ from conf.db.database import Database
 from core.auth.auth_dependencies import RoleChecker, get_current_active_user
 from models import MembreCreate, MembreRead, MembreUpdate, Utilisateur, UtilisateurRead
 
-# MembreSimple est défini localement dans membre_model (hors __init__)
-from models.membre_model import MembreSimple
+# MembreSimple et MembreSimpleWithRoles définis dans membre_model (hors __init__)
+from models.membre_model import MembreSimpleWithRoles
 from models.membre_role_model import MembreRoleCreate, MembreRoleRead
-from models.schema_db_model import Membre, Ministere
+from models.schema_db_model import Membre, MembreRole, Ministere
 from routes.dependance import get_current_membre
 from routes.deps import STANDARD_ADMIN_ONLY_DEPS
 from services.membre_service import MembreService
@@ -86,7 +86,7 @@ def remove_membre_role(
 
 @router.get(
     "/by-ministere/{ministere_id}",
-    response_model=List[MembreSimple],
+    response_model=List[MembreSimpleWithRoles],
     summary="Membres d'un ministère",
     description="Retourne tous les membres actifs liés à un ministère donné.",
 )
@@ -94,11 +94,31 @@ def list_membres_by_ministere(
     ministere_id: str,
     db: Session = Depends(Database.get_db_for_route),
     _: Utilisateur = Depends(get_current_active_user),
-):
+) -> List[MembreSimpleWithRoles]:
+    """Liste les membres actifs d'un ministère avec leurs role_codes."""
+
     ministere = db.exec(select(Ministere).where(Ministere.id == ministere_id)).first()
     if not ministere:
         return []
-    return [m for m in ministere.membres if m.actif]
+    membres_actifs = [m for m in ministere.membres if m.actif]
+    result: List[MembreSimpleWithRoles] = []
+    for m in membres_actifs:
+        roles_stmt = select(MembreRole).where(MembreRole.membre_id == m.id)
+        roles_assoc = list(db.exec(roles_stmt).all())
+        result.append(
+            MembreSimpleWithRoles(
+                id=m.id,
+                nom=m.nom,
+                prenom=m.prenom,
+                email=m.email,
+                telephone=m.telephone,
+                actif=m.actif,
+                campus_principal_id=m.campus_principal_id,
+                date_inscription=m.date_inscription,
+                roles=[r.role_code for r in roles_assoc],
+            )
+        )
+    return result
 
 
 @router.get("/me/agenda")

--- a/backend/src/routes/planning_template_router.py
+++ b/backend/src/routes/planning_template_router.py
@@ -9,6 +9,7 @@ from conf.db.database import Database
 from core.auth.auth_dependencies import RoleChecker, get_current_active_user
 from models import DataListResponse, DataResponse, Utilisateur
 from models.planning_template_model import (
+    ApplyTemplateResultSchema,
     PlanningTemplateFullUpdate,
     PlanningTemplateListItem,
     PlanningTemplateRead,
@@ -167,3 +168,23 @@ def delete_template(
 ) -> None:
     """Supprime un template (nullifie les refs dans les plannings)."""
     svc.delete_template_with_access(template_id, current_user)
+
+
+@router.post(
+    "/{template_id}/apply/{planning_id}",
+    response_model=ApplyTemplateResultSchema,
+    dependencies=[Depends(_WRITE_ROLES)],
+    status_code=200,
+)
+def apply_template(
+    template_id: str,
+    planning_id: str,
+    svc: PlanningTemplateSvc = Depends(_get_svc),
+) -> ApplyTemplateResultSchema:
+    """Applique un template sur un planning existant (US-96).
+
+    Crée des slots et des affectations PROPOSE pour chaque membre suggéré
+    éligible. Retourne les avertissements d'indisponibilité et membres ignorés.
+    """
+    result = svc.apply_to_planning(template_id, planning_id)
+    return ApplyTemplateResultSchema(**result)

--- a/backend/src/services/planning_template_service.py
+++ b/backend/src/services/planning_template_service.py
@@ -1,7 +1,7 @@
 """Service métier pour les templates de planning."""
 
-from datetime import datetime
-from typing import List, Optional
+from datetime import datetime, timedelta
+from typing import List, Optional, Tuple
 from uuid import uuid4
 
 from sqlalchemy import func
@@ -12,20 +12,29 @@ from core.exceptions.app_exception import AppException
 from core.message import ErrorRegistry
 from mla_enum import RoleName
 from models.planning_template_model import (
+    ApplyTemplateResult,
     PlanningTemplateFullUpdate,
     PlanningTemplateListItem,
     PlanningTemplateRead,
+    PlanningTemplateRoleMembreRead,
     PlanningTemplateRoleRead,
+    PlanningTemplateRoleWrite,
     PlanningTemplateSlotRead,
     PlanningTemplateSlotWrite,
     PlanningTemplateUpdate,
     SaveAsTemplateRequest,
+    WarningIndispo,
+    WarningMembreIgnore,
 )
 from models.schema_db_model import (
     Activite,
+    Affectation,
+    Indisponibilite,
+    Membre,
     PlanningService,
     PlanningTemplate,
     PlanningTemplateRole,
+    PlanningTemplateRoleMembre,
     PlanningTemplateSlot,
     Slot,
     Utilisateur,
@@ -233,7 +242,7 @@ class PlanningTemplateSvc:
         return self.get_template(template_id)
 
     def _delete_slots_and_roles(self, template: PlanningTemplate) -> None:
-        """Supprime tous les créneaux (et leurs rôles via cascade) du template."""
+        """Supprime tous les créneaux (et leurs rôles/membres via cascade)."""
         slots = list(
             self.db.exec(
                 select(PlanningTemplateSlot).where(
@@ -250,6 +259,15 @@ class PlanningTemplateSvc:
                 ).all()
             )
             for role in roles:
+                membres = list(
+                    self.db.exec(
+                        select(PlanningTemplateRoleMembre).where(
+                            PlanningTemplateRoleMembre.template_role_id == role.id
+                        )
+                    ).all()
+                )
+                for m in membres:
+                    self.db.delete(m)
                 self.db.delete(role)
             self.db.delete(slot)
         self.db.flush()
@@ -268,16 +286,36 @@ class PlanningTemplateSvc:
         self.db.add(tpl_slot)
         self.db.flush()
         seen: set[str] = set()
-        for role_code in slot_write.roles:
-            if role_code not in seen:
-                seen.add(role_code)
-                self.db.add(
-                    PlanningTemplateRole(
-                        slot_id=tpl_slot.id,
-                        role_code=role_code,
-                    )
-                )
+        for role_write in slot_write.roles:
+            if role_write.role_code not in seen:
+                seen.add(role_write.role_code)
+                self._create_role_with_membres(tpl_slot.id, role_write, db=self.db)
         self.db.flush()
+
+    def _create_role_with_membres(
+        self,
+        slot_id: str,
+        role_write: PlanningTemplateRoleWrite,
+        *,
+        db: Session,
+    ) -> PlanningTemplateRole:
+        """Crée un PlanningTemplateRole avec ses membres suggérés."""
+        role = PlanningTemplateRole(
+            slot_id=slot_id,
+            role_code=role_write.role_code,
+        )
+        db.add(role)
+        db.flush()
+        for membre_id in role_write.membres_suggeres_ids:
+            if db.get(Membre, membre_id) is None:
+                continue
+            db.add(
+                PlanningTemplateRoleMembre(
+                    template_role_id=role.id,
+                    membre_id=membre_id,
+                )
+            )
+        return role
 
     # ── Mise à jour partielle (nom/desc) ───────────────────────────────
 
@@ -338,7 +376,7 @@ class PlanningTemplateSvc:
         )
 
     def _copy_slots(self, source: PlanningTemplate, new_template_id: str) -> None:
-        """Copie tous les créneaux et rôles du template source."""
+        """Copie tous les créneaux, rôles et membres suggérés du template."""
         for slot in source.slots:
             new_slot = PlanningTemplateSlot(
                 template_id=new_template_id,
@@ -350,12 +388,19 @@ class PlanningTemplateSvc:
             self.db.add(new_slot)
             self.db.flush()
             for role in slot.roles:
-                self.db.add(
-                    PlanningTemplateRole(
-                        slot_id=new_slot.id,
-                        role_code=role.role_code,
-                    )
+                new_role = PlanningTemplateRole(
+                    slot_id=new_slot.id,
+                    role_code=role.role_code,
                 )
+                self.db.add(new_role)
+                self.db.flush()
+                for ms in role.membres_suggeres:
+                    self.db.add(
+                        PlanningTemplateRoleMembre(
+                            template_role_id=new_role.id,
+                            membre_id=ms.membre_id,
+                        )
+                    )
         self.db.flush()
 
     # ── Suppression US-95 ─────────────────────────────────────────────
@@ -502,6 +547,223 @@ class PlanningTemplateSvc:
         self.db.flush()
 
     @staticmethod
+    def _role_to_read(role: PlanningTemplateRole) -> PlanningTemplateRoleRead:
+        """Convertit un ORM PlanningTemplateRole en DTO de lecture."""
+        membres: List[PlanningTemplateRoleMembreRead] = []
+        for ms in role.membres_suggeres:
+            m = ms.membre
+            if m is None:
+                continue
+            u = m.utilisateur
+            membres.append(
+                PlanningTemplateRoleMembreRead(
+                    id=ms.id,
+                    membre_id=ms.membre_id,
+                    membre_nom=f"{m.prenom} {m.nom}",
+                    membre_username=u.username if u else "",
+                )
+            )
+        return PlanningTemplateRoleRead(
+            id=role.id,
+            role_code=role.role_code,
+            membres_suggeres=membres,
+        )
+
+    # ── Application d'un template sur un planning US-96 ────────────────
+
+    def apply_to_planning(
+        self, template_id: str, planning_id: str
+    ) -> ApplyTemplateResult:
+        """Applique un template à un planning existant.
+
+        Crée des slots et des affectations PROPOSE pour chaque membre suggéré
+        éligible (actif, dans le bon ministère).
+        Retourne un résultat avec warnings indispo et membres ignorés.
+        """
+        template = self.repo.get_with_slots(template_id)
+        if not template:
+            raise AppException(ErrorRegistry.TMPL_003)
+        planning = self._load_planning_with_activite(planning_id)
+        activite: Activite = planning.activite  # type: ignore[assignment]
+        ministere_id = activite.ministere_organisateur_id
+        planning_date = activite.date_debut.date()
+        avertissements: List[WarningIndispo] = []
+        ignores: List[WarningMembreIgnore] = []
+        nb_creees = 0
+        for tpl_slot in template.slots:
+            slot = self._create_real_slot(planning_id, tpl_slot, activite)
+            for role in tpl_slot.roles:
+                counts = self._apply_role_membres(
+                    role,
+                    slot=slot,
+                    ministere_id=ministere_id,
+                    planning_date_str=str(planning_date),
+                )
+                nb_creees += counts[0]
+                avertissements.extend(counts[1])
+                ignores.extend(counts[2])
+        self.db.flush()
+        return ApplyTemplateResult(
+            planning_id=planning_id,
+            affectations_creees=nb_creees,
+            avertissements_indispo=avertissements,
+            membres_ignores=ignores,
+        )
+
+    def _load_planning_with_activite(self, planning_id: str) -> PlanningService:
+        """Charge un planning avec son activité."""
+        stmt = (
+            select(PlanningService)
+            .where(PlanningService.id == planning_id)
+            .options(
+                selectinload(PlanningService.activite),  # type: ignore[arg-type]
+            )
+        )
+        planning = self.db.exec(stmt).first()
+        if not planning or not planning.activite:
+            raise AppException(ErrorRegistry.PLAN_014)
+        return planning
+
+    def _create_real_slot(
+        self,
+        planning_id: str,
+        tpl_slot: PlanningTemplateSlot,
+        activite: Activite,
+    ) -> Slot:
+        """Crée un Slot réel depuis un slot de template."""
+        debut = activite.date_debut + timedelta(minutes=tpl_slot.offset_debut_minutes)
+        fin = activite.date_debut + timedelta(minutes=tpl_slot.offset_fin_minutes)
+        slot = Slot(
+            planning_id=planning_id,
+            nom_creneau=tpl_slot.nom_creneau,
+            date_debut=debut,
+            date_fin=fin,
+            nb_personnes_requis=tpl_slot.nb_personnes_requis,
+        )
+        self.db.add(slot)
+        self.db.flush()
+        return slot
+
+    def _apply_role_membres(
+        self,
+        role: PlanningTemplateRole,
+        *,
+        slot: Slot,
+        ministere_id: str,
+        planning_date_str: str,
+    ) -> Tuple[int, List[WarningIndispo], List[WarningMembreIgnore]]:
+        """Crée les affectations pour tous les membres suggérés d'un rôle."""
+        nb = 0
+        warns: List[WarningIndispo] = []
+        ignores: List[WarningMembreIgnore] = []
+        for ms in role.membres_suggeres:
+            aff, w_i, w_ig = self._apply_membre_suggere(
+                ms.membre_id,
+                slot=slot,
+                role_code=role.role_code,
+                ministere_id=ministere_id,
+                planning_date_str=planning_date_str,
+            )
+            if aff is not None:
+                nb += 1
+            if w_i is not None:
+                warns.append(w_i)
+            if w_ig is not None:
+                ignores.append(w_ig)
+        return nb, warns, ignores
+
+    def _check_membre_eligibilite(
+        self,
+        membre: Membre,
+        *,
+        ministere_id: str,
+    ) -> Optional[str]:
+        """Retourne la raison d'exclusion ou None si éligible."""
+        if not membre.actif:
+            return "introuvable"
+        ids = [str(m.id) for m in (membre.ministeres or [])]
+        if ministere_id not in ids:
+            return "hors_ministere"
+        return None
+
+    def _check_indisponibilite(
+        self,
+        *,
+        membre_id: str,
+        planning_date_str: str,
+    ) -> bool:
+        """Retourne True si le membre est indisponible à la date donnée."""
+        stmt = select(Indisponibilite).where(
+            Indisponibilite.membre_id == membre_id,
+        )
+        rows = self.db.exec(stmt).all()
+        for row in rows:
+            if row.date_debut is None or row.date_fin is None:
+                continue
+            if row.date_debut <= planning_date_str <= row.date_fin:
+                return True
+        return False
+
+    def _apply_membre_suggere(
+        self,
+        membre_id: str,
+        *,
+        slot: Slot,
+        role_code: str,
+        ministere_id: str,
+        planning_date_str: str,
+    ) -> Tuple[
+        Optional[Affectation],
+        Optional[WarningIndispo],
+        Optional[WarningMembreIgnore],
+    ]:
+        """Tente de créer une affectation pour un membre suggéré."""
+        membre = self.db.get(Membre, membre_id)
+        if membre is None:
+            return (
+                None,
+                None,
+                WarningMembreIgnore(
+                    membre_id=membre_id,
+                    membre_nom="Inconnu",
+                    role_code=role_code,
+                    raison="introuvable",
+                ),
+            )
+        raison = self._check_membre_eligibilite(membre, ministere_id=ministere_id)
+        if raison is not None:
+            return (
+                None,
+                None,
+                WarningMembreIgnore(
+                    membre_id=membre_id,
+                    membre_nom=f"{membre.prenom} {membre.nom}",
+                    role_code=role_code,
+                    raison=raison,
+                ),
+            )
+        w_indispo: Optional[WarningIndispo] = None
+        if self._check_indisponibilite(
+            membre_id=membre_id,
+            planning_date_str=planning_date_str,
+        ):
+            w_indispo = WarningIndispo(
+                membre_id=membre_id,
+                membre_nom=f"{membre.prenom} {membre.nom}",
+                creneau_nom=slot.nom_creneau,
+                role_code=role_code,
+            )
+        affectation = Affectation(
+            slot_id=slot.id,
+            membre_id=membre_id,
+            role_code=role_code,
+            statut_affectation_code="PROPOSE",
+            ministere_id=ministere_id,
+        )
+        self.db.add(affectation)
+        return affectation, w_indispo, None
+
+    @staticmethod
     def _to_read(template: PlanningTemplate) -> PlanningTemplateRead:
         """Convertit un ORM PlanningTemplate en DTO de lecture."""
         return PlanningTemplateRead(
@@ -522,10 +784,7 @@ class PlanningTemplateSvc:
                     offset_debut_minutes=s.offset_debut_minutes,
                     offset_fin_minutes=s.offset_fin_minutes,
                     nb_personnes_requis=s.nb_personnes_requis,
-                    roles=[
-                        PlanningTemplateRoleRead(id=r.id, role_code=r.role_code)
-                        for r in s.roles
-                    ],
+                    roles=[PlanningTemplateSvc._role_to_read(r) for r in s.roles],
                 )
                 for s in template.slots
             ],

--- a/backend/src/tests/test_planning_template.py
+++ b/backend/src/tests/test_planning_template.py
@@ -15,17 +15,27 @@ from core.message import ErrorRegistry
 from mla_enum import RoleName
 from models import (
     Activite,
+    Affectation,
     AffectationRole,
     Campus,
     PlanningService,
     Role,
+    Slot,
     Utilisateur,
 )
 from models.planning_template_model import (
     PlanningTemplateFullUpdate,
+    PlanningTemplateRoleWrite,
     PlanningTemplateSlotWrite,
 )
-from models.schema_db_model import PlanningTemplate, PlanningTemplateSlot
+from models.schema_db_model import (
+    Indisponibilite,
+    Membre,
+    PlanningTemplate,
+    PlanningTemplateRole,
+    PlanningTemplateRoleMembre,
+    PlanningTemplateSlot,
+)
 from services.planning_template_service import PlanningTemplateSvc
 
 # ---------------------------------------------------------------------------
@@ -241,7 +251,10 @@ def test_update_template(session, test_admin, test_membre, template_fixture):
                 offset_debut_minutes=0,
                 offset_fin_minutes=60,
                 nb_personnes_requis=3,
-                roles=["TENOR", "SON"],
+                roles=[
+                    PlanningTemplateRoleWrite(role_code="TENOR"),
+                    PlanningTemplateRoleWrite(role_code="SON"),
+                ],
             )
         ],
     )
@@ -328,3 +341,325 @@ def test_api_delete_template_forbidden(
         headers=responsable_headers,
     )
     assert resp.status_code == status.HTTP_403_FORBIDDEN
+
+
+# ---------------------------------------------------------------------------
+# Fixtures US-96
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def membre_dans_ministere(session: Session, test_campus, test_ministere) -> Membre:
+    """Membre actif, lié au test_ministere."""
+    m = Membre(
+        nom=f"Test{uuid4().hex[:4]}",
+        prenom="Membre",
+        email=f"membre_{uuid4().hex[:6]}@test.com",
+        actif=True,
+    )
+    m.campuses = [test_campus]
+    m.ministeres = [test_ministere]
+    session.add(m)
+    session.flush()
+    session.refresh(m)
+    return m
+
+
+@pytest.fixture
+def template_avec_membres(
+    session: Session, test_campus, test_ministere, test_membre, membre_dans_ministere
+) -> PlanningTemplate:
+    """Template avec 1 slot, 1 rôle, 1 membre suggéré (éligible)."""
+    tpl = PlanningTemplate(
+        nom="Template US96",
+        description=None,
+        activite_type="Culte",
+        duree_minutes=120,
+        campus_id=test_campus.id,
+        ministere_id=test_ministere.id,
+        created_by_id=test_membre.id,
+    )
+    session.add(tpl)
+    session.flush()
+    slot = PlanningTemplateSlot(
+        template_id=tpl.id,
+        nom_creneau="Louange",
+        offset_debut_minutes=0,
+        offset_fin_minutes=60,
+        nb_personnes_requis=1,
+    )
+    session.add(slot)
+    session.flush()
+    role = PlanningTemplateRole(slot_id=slot.id, role_code="TENOR")
+    session.add(role)
+    session.flush()
+    session.add(
+        PlanningTemplateRoleMembre(
+            template_role_id=role.id,
+            membre_id=membre_dans_ministere.id,
+        )
+    )
+    session.flush()
+    session.refresh(tpl)
+    return tpl
+
+
+@pytest.fixture
+def planning_vide(
+    session: Session, test_campus, test_ministere, template_avec_membres
+) -> PlanningService:
+    """Planning BROUILLON lié au template_avec_membres."""
+    base = datetime(2026, 7, 1, 9, 0)
+    activite = Activite(
+        type="Culte",
+        date_debut=base,
+        date_fin=base + timedelta(hours=2),
+        campus_id=test_campus.id,
+        ministere_organisateur_id=test_ministere.id,
+    )
+    session.add(activite)
+    session.flush()
+    planning = PlanningService(
+        activite_id=activite.id,
+        statut_code="BROUILLON",
+        template_id=template_avec_membres.id,
+    )
+    session.add(planning)
+    session.flush()
+    session.refresh(planning)
+    return planning
+
+
+@pytest.fixture
+def indispo_fixture(
+    session: Session, membre_dans_ministere, test_ministere
+) -> Indisponibilite:
+    """Indisponibilité couvrant 2026-07-01 pour membre_dans_ministere."""
+    indispo = Indisponibilite(
+        membre_id=membre_dans_ministere.id,
+        date_debut="2026-07-01",
+        date_fin="2026-07-01",
+        motif="Test indispo",
+        validee=True,
+        ministere_id=test_ministere.id,
+    )
+    session.add(indispo)
+    session.flush()
+    return indispo
+
+
+# ---------------------------------------------------------------------------
+# Tests US-96
+# ---------------------------------------------------------------------------
+
+
+def test_update_template_with_membres_suggeres(
+    session, test_admin, test_membre, template_fixture, membre_dans_ministere
+):
+    """PUT template avec membres_suggeres_ids → membres sauvegardés."""
+    test_admin.membre_id = test_membre.id
+    session.add(test_admin)
+    session.flush()
+    svc = PlanningTemplateSvc(session)
+    payload = PlanningTemplateFullUpdate(
+        nom=template_fixture.nom,
+        description=None,
+        slots=[
+            PlanningTemplateSlotWrite(
+                nom_creneau="Louange",
+                offset_debut_minutes=0,
+                offset_fin_minutes=60,
+                nb_personnes_requis=1,
+                roles=[
+                    PlanningTemplateRoleWrite(
+                        role_code="TENOR",
+                        membres_suggeres_ids=[membre_dans_ministere.id],
+                    )
+                ],
+            )
+        ],
+    )
+    result = svc.update_template_full(template_fixture.id, payload, test_admin)
+    assert len(result.slots) == 1
+    roles = result.slots[0].roles
+    assert len(roles) == 1
+    assert len(roles[0].membres_suggeres) == 1
+    assert roles[0].membres_suggeres[0].membre_id == membre_dans_ministere.id
+
+
+def test_template_role_read_includes_membres(
+    session, test_admin, test_membre, template_avec_membres
+):
+    """GET template → slots[].roles[].membres_suggeres non vide."""
+    test_admin.membre_id = test_membre.id
+    session.add(test_admin)
+    session.flush()
+    svc = PlanningTemplateSvc(session)
+    result = svc.get_template_full(template_avec_membres.id, test_admin)
+    assert len(result.slots) == 1
+    assert len(result.slots[0].roles) == 1
+    membres = result.slots[0].roles[0].membres_suggeres
+    assert len(membres) == 1
+
+
+def test_apply_template_creates_affectations_propose(
+    session, test_admin, test_membre, template_avec_membres, planning_vide
+):
+    """Application → affectation PROPOSE créée en DB."""
+    test_admin.membre_id = test_membre.id
+    session.add(test_admin)
+    session.flush()
+    svc = PlanningTemplateSvc(session)
+    result = svc.apply_to_planning(template_avec_membres.id, planning_vide.id)
+    assert result["affectations_creees"] == 1
+    aff = session.exec(
+        select(Affectation).where(Affectation.statut_affectation_code == "PROPOSE")
+    ).first()
+    assert aff is not None
+
+
+def test_apply_template_ignore_membre_introuvable(
+    session, test_admin, test_membre, test_campus, test_ministere
+):
+    """_apply_membre_suggere avec UUID inexistant → raison introuvable."""
+    test_admin.membre_id = test_membre.id
+    session.add(test_admin)
+    session.flush()
+    # On appelle directement la méthode helper du service
+    svc = PlanningTemplateSvc(session)
+    base = datetime(2026, 8, 1, 9, 0)
+    act = Activite(
+        type="Culte",
+        date_debut=base,
+        date_fin=base + timedelta(hours=2),
+        campus_id=test_campus.id,
+        ministere_organisateur_id=test_ministere.id,
+    )
+    session.add(act)
+    session.flush()
+    planning = PlanningService(activite_id=act.id, statut_code="BROUILLON")
+    session.add(planning)
+    session.flush()
+    fake_slot = Slot(
+        planning_id=planning.id,
+        nom_creneau="Test",
+        date_debut=base,
+        date_fin=base + timedelta(hours=1),
+    )
+    session.add(fake_slot)
+    session.flush()
+    fake_id = "00000000-0000-0000-0000-000000000099"
+    _aff, _wi, w_ig = svc._apply_membre_suggere(  # pylint: disable=W0212
+        fake_id,
+        slot=fake_slot,
+        role_code="TENOR",
+        ministere_id=test_ministere.id,
+        planning_date_str="2026-08-01",
+    )
+    assert w_ig is not None
+    assert w_ig["raison"] == "introuvable"
+
+
+def test_apply_template_ignore_membre_hors_ministere(
+    session, test_admin, test_membre, template_avec_membres, planning_vide
+):
+    """Membre non lié au ministère → ignoré avec raison hors_ministere."""
+    test_admin.membre_id = test_membre.id
+    session.add(test_admin)
+    session.flush()
+    # Ajouter test_membre (sans ministere_link) au rôle
+    tpl_slot = session.exec(
+        select(PlanningTemplateSlot).where(
+            PlanningTemplateSlot.template_id == template_avec_membres.id
+        )
+    ).first()
+    assert tpl_slot is not None
+    tpl_role = session.exec(
+        select(PlanningTemplateRole).where(PlanningTemplateRole.slot_id == tpl_slot.id)
+    ).first()
+    assert tpl_role is not None
+    # test_membre n'est pas dans test_ministere
+    session.add(
+        PlanningTemplateRoleMembre(
+            template_role_id=tpl_role.id, membre_id=test_membre.id
+        )
+    )
+    session.flush()
+    svc = PlanningTemplateSvc(session)
+    result = svc.apply_to_planning(template_avec_membres.id, planning_vide.id)
+    raisons = [ig["raison"] for ig in result["membres_ignores"]]
+    assert "hors_ministere" in raisons
+
+
+def test_apply_template_warning_indisponibilite(  # pylint: disable=R0917
+    session,
+    test_admin,
+    test_membre,
+    template_avec_membres,
+    planning_vide,
+    indispo_fixture,
+):
+    """Membre indispo → affectation quand même créée + dans avertissements."""
+    test_admin.membre_id = test_membre.id
+    session.add(test_admin)
+    session.flush()
+    svc = PlanningTemplateSvc(session)
+    result = svc.apply_to_planning(template_avec_membres.id, planning_vide.id)
+    assert result["affectations_creees"] == 1
+    assert len(result["avertissements_indispo"]) == 1
+
+
+def test_apply_template_membre_plusieurs_roles(  # pylint: disable=R0917
+    session, test_admin, test_membre, test_campus, test_ministere, membre_dans_ministere
+):
+    """Même membre sur 2 rôles → 2 affectations PROPOSE distinctes."""
+    test_admin.membre_id = test_membre.id
+    session.add(test_admin)
+    session.flush()
+    tpl = PlanningTemplate(
+        nom="Tpl 2 roles",
+        description=None,
+        activite_type="Culte",
+        duree_minutes=120,
+        campus_id=test_campus.id,
+        ministere_id=test_ministere.id,
+        created_by_id=test_membre.id,
+    )
+    session.add(tpl)
+    session.flush()
+    slot = PlanningTemplateSlot(
+        template_id=tpl.id,
+        nom_creneau="Slot",
+        offset_debut_minutes=0,
+        offset_fin_minutes=60,
+        nb_personnes_requis=2,
+    )
+    session.add(slot)
+    session.flush()
+    for rc in ["TENOR", "PIANO"]:
+        r = PlanningTemplateRole(slot_id=slot.id, role_code=rc)
+        session.add(r)
+        session.flush()
+        session.add(
+            PlanningTemplateRoleMembre(
+                template_role_id=r.id,
+                membre_id=membre_dans_ministere.id,
+            )
+        )
+    session.flush()
+    base = datetime(2026, 9, 1, 9, 0)
+    act = Activite(
+        type="Culte",
+        date_debut=base,
+        date_fin=base + timedelta(hours=2),
+        campus_id=test_campus.id,
+        ministere_organisateur_id=test_ministere.id,
+    )
+    session.add(act)
+    session.flush()
+    planning = PlanningService(activite_id=act.id, statut_code="BROUILLON")
+    session.add(planning)
+    session.flush()
+    svc = PlanningTemplateSvc(session)
+    result = svc.apply_to_planning(tpl.id, planning.id)
+    assert result["affectations_creees"] == 2

--- a/frontend/layers/base/app/components/AppDrawer.vue
+++ b/frontend/layers/base/app/components/AppDrawer.vue
@@ -41,8 +41,24 @@
               </div>
             </div>
 
-            <div class="custom-scrollbar flex-1 overflow-y-auto p-6">
-              <slot />
+            <div class="relative flex-1 overflow-hidden">
+              <div
+                v-show="showTopFade"
+                class="pointer-events-none absolute inset-x-0 top-0 z-10 h-10 bg-gradient-to-b from-white to-transparent"
+                aria-hidden="true"
+              />
+              <div
+                ref="scrollEl"
+                class="custom-scrollbar h-full overflow-y-auto p-6"
+                @scroll="onScroll"
+              >
+                <slot />
+              </div>
+              <div
+                v-show="showBottomFade"
+                class="pointer-events-none absolute inset-x-0 bottom-0 z-10 h-10 bg-gradient-to-t from-white to-transparent"
+                aria-hidden="true"
+              />
             </div>
 
             <div v-if="$slots.footer" class="border-t border-slate-100 bg-slate-50 p-4">
@@ -57,7 +73,19 @@
 
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
+
 import { X, Maximize2, Minimize2 } from 'lucide-vue-next'
+
+const scrollEl = ref<HTMLElement | null>(null)
+const showTopFade = ref(false)
+const showBottomFade = ref(true)
+
+function onScroll() {
+  if (!scrollEl.value) return
+  const { scrollTop, scrollHeight, clientHeight } = scrollEl.value
+  showTopFade.value = scrollTop > 8
+  showBottomFade.value = scrollTop + clientHeight < scrollHeight - 8
+}
 
 // Types pour les tailles
 type DrawerSize = 'standard' | 'half' | 'full'

--- a/frontend/layers/planning/app/components/PlanningFormView.vue
+++ b/frontend/layers/planning/app/components/PlanningFormView.vue
@@ -588,6 +588,83 @@
         </div>
       </FormSection>
     </div>
+
+    <!-- ── US-96 : avertissements membres suggérés ──────────────────────── -->
+    <div
+      v-if="applyWarningsIndispo.length > 0 || applyIgnoredMembres.length > 0"
+      class="rounded-xl border border-amber-200 bg-amber-50 p-4"
+    >
+      <div class="mb-3 flex items-center justify-between">
+        <p class="text-sm font-semibold text-amber-800">Avertissements — application du template</p>
+        <button
+          type="button"
+          class="rounded-full p-1 text-amber-500 transition-colors hover:bg-amber-100"
+          @click="dismissApplyWarnings()"
+        >
+          <X class="size-4" />
+        </button>
+      </div>
+
+      <!-- Indisponibilités -->
+      <div v-if="applyWarningsIndispo.length > 0" class="mb-3">
+        <div class="mb-1.5 flex items-center gap-1.5">
+          <AlertTriangle class="size-3.5 text-amber-600" />
+          <p class="text-xs font-semibold text-amber-700">
+            Membres indisponibles à cette date ({{ applyWarningsIndispo.length }})
+          </p>
+        </div>
+        <div class="space-y-1">
+          <div
+            v-for="(w, i) in applyWarningsIndispo"
+            :key="i"
+            class="flex items-center gap-2 rounded-lg bg-amber-100 px-3 py-1.5 text-xs text-amber-800"
+          >
+            <span class="font-medium">{{ w.membre_nom }}</span>
+            <span class="text-amber-600">·</span>
+            <span>{{ w.creneau_nom }}</span>
+            <span
+              class="ml-auto rounded-full bg-amber-200 px-1.5 py-0.5 font-mono text-[10px] text-amber-700"
+            >
+              {{ w.role_code }}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Membres ignorés -->
+      <div v-if="applyIgnoredMembres.length > 0">
+        <div class="mb-1.5 flex items-center gap-1.5">
+          <UserX class="size-3.5 text-slate-500" />
+          <p class="text-xs font-semibold text-slate-600">
+            Membres ignorés ({{ applyIgnoredMembres.length }})
+          </p>
+        </div>
+        <div class="space-y-1">
+          <div
+            v-for="(w, i) in applyIgnoredMembres"
+            :key="i"
+            class="flex items-center gap-2 rounded-lg bg-slate-100 px-3 py-1.5 text-xs text-slate-700"
+          >
+            <span class="font-medium">{{ w.membre_nom }}</span>
+            <span class="text-slate-400">·</span>
+            <span
+              class="ml-auto rounded-full bg-slate-200 px-1.5 py-0.5 font-mono text-[10px] text-slate-600"
+            >
+              {{ w.role_code }}
+            </span>
+            <span
+              class="rounded-full px-1.5 py-0.5 text-[10px] font-medium"
+              :class="{
+                'bg-orange-100 text-orange-700': w.raison === 'hors_ministere',
+                'bg-slate-200 text-slate-600': w.raison !== 'hors_ministere',
+              }"
+            >
+              {{ w.raison }}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
   </form>
 </template>
 
@@ -603,6 +680,8 @@ import {
   Clock,
   Users as UsersIcon,
   BookmarkPlus,
+  AlertTriangle,
+  UserX,
 } from 'lucide-vue-next'
 import FormSection from '~~/layers/base/app/components/FormSection.vue'
 import { planningFormKey } from '../composables/usePlanningForm'
@@ -641,6 +720,8 @@ const {
   formTargetStatus,
   selectedTemplateId,
   templateApplied,
+  applyWarningsIndispo,
+  applyIgnoredMembres,
   toggleSection,
   selectMinistere,
   onDateDebutChange,
@@ -656,6 +737,7 @@ const {
   rolesForMembre,
   loadMinistreresForCampus,
   applyTemplate,
+  dismissApplyWarnings,
   internalMode,
 } = form
 

--- a/frontend/layers/planning/app/components/TemplateEditDrawer.vue
+++ b/frontend/layers/planning/app/components/TemplateEditDrawer.vue
@@ -1,9 +1,15 @@
 <script setup lang="ts">
 import { ref, reactive, watch } from 'vue'
 import { storeToRefs } from 'pinia'
-import { Plus, Trash2, ChevronUp, ChevronDown } from 'lucide-vue-next'
+import { Plus, Trash2, ChevronUp, ChevronDown, AlertTriangle } from 'lucide-vue-next'
 import { usePlanningTemplateStore } from '../stores/usePlanningTemplateStore'
-import type { PlanningTemplateSlotWrite } from '../types/planning.types'
+import { PlanningRepository } from '../repositories/PlanningRepository'
+import type {
+  MembreSimple,
+  PlanningTemplateSlotWrite,
+  RoleCompetenceRead,
+  TemplateRoleWrite,
+} from '../types/planning.types'
 
 const props = defineProps<{
   templateId: string | null
@@ -15,6 +21,7 @@ const emit = defineEmits<{
 
 const templateStore = usePlanningTemplateStore()
 const { selectedTemplate, isLoading } = storeToRefs(templateStore)
+const repo = new PlanningRepository()
 
 interface SlotForm extends PlanningTemplateSlotWrite {
   _tempId: string
@@ -28,6 +35,25 @@ const form = reactive<{
 
 const isSaving = ref(false)
 const loadError = ref<string | null>(null)
+const membresDisponibles = ref<MembreSimple[]>([])
+const rolesCompetences = ref<RoleCompetenceRead[]>([])
+const roleErrors = ref<Record<string, string | null>>({})
+
+async function loadMembres(ministereId: string) {
+  try {
+    membresDisponibles.value = await repo.getMembersByMinistere(ministereId)
+  } catch {
+    membresDisponibles.value = []
+  }
+}
+
+async function loadRoles() {
+  try {
+    rolesCompetences.value = await repo.getRoleCompetences()
+  } catch {
+    rolesCompetences.value = []
+  }
+}
 
 function populateForm() {
   const tpl = selectedTemplate.value
@@ -40,7 +66,12 @@ function populateForm() {
     offset_debut_minutes: s.offset_debut_minutes,
     offset_fin_minutes: s.offset_fin_minutes,
     nb_personnes_requis: s.nb_personnes_requis,
-    roles: s.roles.map((r) => r.role_code),
+    roles: s.roles.map(
+      (r): TemplateRoleWrite => ({
+        role_code: r.role_code,
+        membres_suggeres_ids: r.membres_suggeres.map((m) => m.membre_id),
+      }),
+    ),
   }))
 }
 
@@ -52,6 +83,12 @@ watch(
     try {
       await templateStore.fetchTemplate(id)
       populateForm()
+      await Promise.all([
+        loadRoles(),
+        selectedTemplate.value?.ministere_id
+          ? loadMembres(selectedTemplate.value.ministere_id)
+          : Promise.resolve(),
+      ])
     } catch {
       loadError.value = 'Impossible de charger ce template.'
     }
@@ -83,11 +120,46 @@ function moveSlot(index: number, direction: 'up' | 'down') {
 }
 
 function addRole(slot: SlotForm) {
-  slot.roles.push('')
+  slot.roles.push({ role_code: '', membres_suggeres_ids: [] })
 }
 
 function removeRole(slot: SlotForm, rIdx: number) {
   slot.roles.splice(rIdx, 1)
+}
+
+function clearRoleError(sIdx: number, rIdx: number) {
+  roleErrors.value[`${sIdx}-${rIdx}`] = null
+}
+
+function addSuggestedMember(role: TemplateRoleWrite, membreId: string, sIdx: number, rIdx: number) {
+  if (!membreId) return
+  if (role.membres_suggeres_ids.includes(membreId)) return
+
+  if (role.role_code.trim() !== '') {
+    const membre = membresDisponibles.value.find((m) => m.id === membreId)
+    if (membre && membre.roles.length > 0) {
+      const roleCode = role.role_code.trim().toUpperCase()
+      if (!membre.roles.map((r) => r.toUpperCase()).includes(roleCode)) {
+        roleErrors.value[`${sIdx}-${rIdx}`] =
+          `${membre.prenom} ${membre.nom} n'a pas la compétence ` +
+          `« ${roleCode} » requise pour ce rôle.`
+        return
+      }
+    }
+  }
+
+  roleErrors.value[`${sIdx}-${rIdx}`] = null
+  role.membres_suggeres_ids.push(membreId)
+}
+
+function removeSuggestedMember(role: TemplateRoleWrite, membreId: string) {
+  const idx = role.membres_suggeres_ids.indexOf(membreId)
+  if (idx !== -1) role.membres_suggeres_ids.splice(idx, 1)
+}
+
+function membreLabel(id: string): string {
+  const m = membresDisponibles.value.find((x) => x.id === id)
+  return m ? `${m.prenom} ${m.nom}` : id
 }
 
 async function handleSave() {
@@ -102,7 +174,7 @@ async function handleSave() {
         offset_debut_minutes: s.offset_debut_minutes,
         offset_fin_minutes: s.offset_fin_minutes,
         nb_personnes_requis: s.nb_personnes_requis,
-        roles: s.roles.filter((r) => r.trim() !== ''),
+        roles: s.roles.filter((r) => r.role_code.trim() !== ''),
       })),
     })
     emit('saved')
@@ -117,7 +189,7 @@ async function handleSave() {
   <AppDrawer
     :isOpen="templateId !== null"
     :title="form.nom || 'Modifier le template'"
-    initialSize="half"
+    initialSize="standard"
     @close="emit('close')"
   >
     <!-- Corps -->
@@ -277,8 +349,8 @@ async function handleSave() {
               </div>
 
               <!-- Rôles -->
-              <div class="mt-3">
-                <div class="mb-1 flex items-center justify-between">
+              <div class="mt-3 space-y-3">
+                <div class="flex items-center justify-between">
                   <label class="text-xs font-medium text-slate-600">Rôles requis</label>
                   <button
                     type="button"
@@ -288,25 +360,105 @@ async function handleSave() {
                     + Ajouter
                   </button>
                 </div>
-                <div class="flex flex-wrap gap-2">
-                  <div v-for="(_, rIdx) in slot.roles" :key="rIdx" class="flex items-center gap-1">
-                    <input
-                      v-model="slot.roles[rIdx]"
-                      type="text"
-                      class="w-28 rounded border border-slate-300 px-2 py-1 text-xs uppercase outline-none focus:border-blue-400"
-                      placeholder="ROLE_CODE"
-                    />
+
+                <p v-if="slot.roles.length === 0" class="text-xs text-slate-400 italic">
+                  Aucun rôle
+                </p>
+
+                <div
+                  v-for="(role, rIdx) in slot.roles"
+                  :key="rIdx"
+                  class="rounded-md border border-slate-200 bg-white p-3"
+                >
+                  <!-- Code rôle + supprimer -->
+                  <div class="mb-2 flex items-center gap-2">
+                    <select
+                      v-model="role.role_code"
+                      class="flex-1 rounded border border-slate-300 px-2 py-1 text-xs text-slate-700 outline-none focus:border-blue-400"
+                      @change="clearRoleError(idx, rIdx)"
+                    >
+                      <option value="">— Choisir un rôle —</option>
+                      <option v-for="rc in rolesCompetences" :key="rc.code" :value="rc.code">
+                        {{ rc.libelle }}
+                      </option>
+                    </select>
                     <button
                       type="button"
-                      class="text-slate-400 hover:text-red-500"
+                      class="shrink-0 text-slate-400 hover:text-red-500"
                       @click="removeRole(slot, rIdx)"
                     >
                       <Trash2 class="size-3.5" />
                     </button>
                   </div>
-                  <span v-if="slot.roles.length === 0" class="text-xs text-slate-400 italic">
-                    Aucun rôle
-                  </span>
+
+                  <!-- Membres suggérés -->
+                  <div class="space-y-1.5">
+                    <p class="text-xs font-medium text-slate-500">Membres suggérés</p>
+
+                    <!-- Tags membres déjà ajoutés -->
+                    <div v-if="role.membres_suggeres_ids.length > 0" class="flex flex-wrap gap-1">
+                      <span
+                        v-for="membreId in role.membres_suggeres_ids"
+                        :key="membreId"
+                        class="flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800"
+                      >
+                        {{ membreLabel(membreId) }}
+                        <button
+                          type="button"
+                          class="text-blue-500 hover:text-blue-800"
+                          @click="removeSuggestedMember(role, membreId)"
+                        >
+                          ×
+                        </button>
+                      </span>
+                    </div>
+
+                    <!-- Select pour ajouter un membre -->
+                    <select
+                      v-if="membresDisponibles.length > 0"
+                      class="w-full rounded border border-slate-300 px-2 py-1 text-xs text-slate-700 outline-none focus:border-blue-400"
+                      @change="
+                        (e) => {
+                          const val = (e.target as HTMLSelectElement).value
+                          if (val) {
+                            addSuggestedMember(role, val, idx, rIdx)
+                            ;(e.target as HTMLSelectElement).value = ''
+                          } else {
+                            clearRoleError(idx, rIdx)
+                          }
+                        }
+                      "
+                    >
+                      <option value="">— Ajouter un membre —</option>
+                      <option
+                        v-for="m in membresDisponibles.filter(
+                          (x) => !role.membres_suggeres_ids.includes(x.id),
+                        )"
+                        :key="m.id"
+                        :value="m.id"
+                      >
+                        {{ m.prenom }} {{ m.nom
+                        }}{{
+                          role.role_code &&
+                          m.roles.length > 0 &&
+                          !m.roles
+                            .map((r) => r.toUpperCase())
+                            .includes(role.role_code.toUpperCase())
+                            ? ' (hors compétence)'
+                            : ''
+                        }}
+                      </option>
+                    </select>
+
+                    <!-- Erreur de compétence par rôle -->
+                    <p
+                      v-if="roleErrors[`${idx}-${rIdx}`]"
+                      class="mt-1 flex items-center gap-1.5 text-xs font-medium text-red-600"
+                    >
+                      <AlertTriangle class="size-3.5 shrink-0" />
+                      {{ roleErrors[`${idx}-${rIdx}`] }}
+                    </p>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/layers/planning/app/composables/usePlanningForm.ts
+++ b/frontend/layers/planning/app/composables/usePlanningForm.ts
@@ -11,8 +11,10 @@ import {
 } from 'vue'
 import { PlanningRepository } from '../repositories/PlanningRepository'
 import type {
+  AffectationFormItem,
   AffectationStatus,
   ActiviteFormState,
+  ApplyTemplateResult,
   CampusTeamRead,
   MinistereColor,
   PlanningFullRead,
@@ -20,6 +22,8 @@ import type {
   RoleCompetenceRead,
   SlotFormItem,
   TeamMemberRead,
+  WarningIndispo,
+  WarningMembreIgnore,
 } from '../types/planning.types'
 import { getMinistereColor } from '../types/planning.types'
 import { TRANSITION_META } from './usePlanningWorkflow'
@@ -161,6 +165,8 @@ export function usePlanningForm(
   const slotPickers = ref<SlotPickerState[]>([])
   const selectedTemplateId = ref<string | null>(null)
   const templateApplied = ref(false)
+  const applyWarningsIndispo = ref<WarningIndispo[]>([])
+  const applyIgnoredMembres = ref<WarningMembreIgnore[]>([])
   const isSaving = ref(false)
   const apiError = ref<string | null>(null)
   const formTargetStatus = ref<string>('BROUILLON')
@@ -397,6 +403,12 @@ export function usePlanningForm(
     slotPickers.value[slotIdx] = defaultPicker()
   }
 
+  function dismissApplyWarnings(): void {
+    applyWarningsIndispo.value = []
+    applyIgnoredMembres.value = []
+    callbacks.onClose()
+  }
+
   function rolesForMembre(membreId: string): RoleCompetenceRead[] {
     if (!campusTeam.value) return roles.value
     for (const min of campusTeam.value.ministeres) {
@@ -406,6 +418,19 @@ export function usePlanningForm(
       }
     }
     return roles.value
+  }
+
+  /**
+   * Résout un membre depuis campusTeam à partir de son ID.
+   * Retourne null si introuvable.
+   */
+  function resolveMembre(membreId: string): { prenom: string; nom: string } | null {
+    if (!campusTeam.value) return null
+    for (const min of campusTeam.value.ministeres) {
+      const m = min.membres.find((mb) => mb.id === membreId)
+      if (m) return { prenom: m.prenom, nom: m.nom }
+    }
+    return null
   }
 
   function applyTemplate(template: PlanningTemplateRead): void {
@@ -420,14 +445,49 @@ export function usePlanningForm(
     }
 
     // 3. Construire les slots depuis les créneaux du template
-    const newSlots: SlotFormItem[] = template.slots.map((tplSlot) => ({
-      _tempId: newTempId(),
-      nom_creneau: tplSlot.nom_creneau,
-      heure_debut: offsetToHHMM(activiteForm.date_debut, tplSlot.offset_debut_minutes),
-      heure_fin: offsetToHHMM(activiteForm.date_debut, tplSlot.offset_fin_minutes),
-      nb_personnes_requis: tplSlot.nb_personnes_requis,
-      affectations: [],
-    }))
+    const newSlots: SlotFormItem[] = template.slots.map((tplSlot) => {
+      const affectations: AffectationFormItem[] = []
+
+      for (const role of tplSlot.roles) {
+        for (const membreSuggere of role.membres_suggeres ?? []) {
+          const alreadyAdded = affectations.some(
+            (a) => a.membre_id === membreSuggere.membre_id && a.role_code === role.role_code,
+          )
+          if (alreadyAdded) continue
+
+          const resolved = resolveMembre(membreSuggere.membre_id)
+          let prenom = ''
+          let nom = membreSuggere.membre_nom ?? ''
+          if (resolved) {
+            prenom = resolved.prenom
+            nom = resolved.nom
+          } else if (membreSuggere.membre_nom) {
+            const parts = membreSuggere.membre_nom.split(' ')
+            prenom = parts[0] ?? ''
+            nom = parts.slice(1).join(' ')
+          }
+
+          affectations.push({
+            _tempId: `suggest-${membreSuggere.membre_id}-${role.role_code}-${Date.now()}`,
+            membre_id: membreSuggere.membre_id,
+            membre_prenom: prenom,
+            membre_nom: nom,
+            role_code: role.role_code,
+            ministere_id: template.ministere_id,
+            statut_affectation_code: 'PROPOSE',
+          })
+        }
+      }
+
+      return {
+        _tempId: newTempId(),
+        nom_creneau: tplSlot.nom_creneau,
+        heure_debut: offsetToHHMM(activiteForm.date_debut, tplSlot.offset_debut_minutes),
+        heure_fin: offsetToHHMM(activiteForm.date_debut, tplSlot.offset_fin_minutes),
+        nb_personnes_requis: tplSlot.nb_personnes_requis,
+        affectations,
+      }
+    })
 
     slotsForm.value = newSlots
     slotPickers.value = newSlots.map(() => defaultPicker())
@@ -453,6 +513,8 @@ export function usePlanningForm(
     slotsForm.value = []
     slotPickers.value = []
     apiError.value = null
+    applyWarningsIndispo.value = []
+    applyIgnoredMembres.value = []
     activeSections.value = new Set(['activite'])
     formTargetStatus.value = 'BROUILLON'
 
@@ -567,10 +629,28 @@ export function usePlanningForm(
         result = await repo.updateStatus(result.id, targetStatus)
       }
 
+      // US-96 : application des membres suggérés du template sur le planning créé
+      if (internalMode.value === 'create' && selectedTemplateId.value) {
+        try {
+          const applyResult: ApplyTemplateResult = await repo.applyTemplate(
+            selectedTemplateId.value,
+            result.id,
+          )
+          applyWarningsIndispo.value = applyResult.avertissements_indispo
+          applyIgnoredMembres.value = applyResult.membres_ignores
+        } catch {
+          // Non bloquant — le planning est créé, les affectations seront à faire manuellement
+        }
+      }
+
       const isNew = internalMode.value === 'create'
       notify.success(isNew ? 'Planning créé' : 'Planning mis à jour', result.activite?.type ?? '')
       callbacks.onSaved(result, isNew)
-      callbacks.onClose()
+      const hasWarnings =
+        applyWarningsIndispo.value.length > 0 || applyIgnoredMembres.value.length > 0
+      if (!hasWarnings) {
+        callbacks.onClose()
+      }
     } catch (e) {
       apiError.value = handleError(e, 'Une erreur est survenue, veuillez réessayer.')
     } finally {
@@ -596,6 +676,8 @@ export function usePlanningForm(
     slotPickers,
     selectedTemplateId,
     templateApplied,
+    applyWarningsIndispo,
+    applyIgnoredMembres,
     isSaving,
     apiError,
     formTargetStatus,
@@ -624,6 +706,7 @@ export function usePlanningForm(
     resetPicker,
     rolesForMembre,
     applyTemplate,
+    dismissApplyWarnings,
     initForm,
     save,
   }

--- a/frontend/layers/planning/app/pages/planning/templates/[id]/edit.vue
+++ b/frontend/layers/planning/app/pages/planning/templates/[id]/edit.vue
@@ -3,11 +3,17 @@ import { ref, reactive, onMounted } from 'vue'
 import { storeToRefs } from 'pinia'
 import { ArrowLeft, Plus, Trash2, ChevronUp, ChevronDown } from 'lucide-vue-next'
 import { usePlanningTemplateStore } from '../../../../stores/usePlanningTemplateStore'
-import type { PlanningTemplateSlotWrite } from '../../../../types/planning.types'
+import { PlanningRepository } from '../../../../repositories/PlanningRepository'
+import type {
+  MembreSimple,
+  PlanningTemplateSlotWrite,
+  TemplateRoleWrite,
+} from '../../../../types/planning.types'
 
 const route = useRoute()
 const templateStore = usePlanningTemplateStore()
 const { selectedTemplate, isLoading } = storeToRefs(templateStore)
+const repo = new PlanningRepository()
 
 const templateId = route.params.id as string
 
@@ -27,6 +33,7 @@ const form = reactive<{
 
 const isSaving = ref(false)
 const loadError = ref<string | null>(null)
+const membresDisponibles = ref<MembreSimple[]>([])
 
 onMounted(async () => {
   try {
@@ -41,8 +48,20 @@ onMounted(async () => {
         offset_debut_minutes: s.offset_debut_minutes,
         offset_fin_minutes: s.offset_fin_minutes,
         nb_personnes_requis: s.nb_personnes_requis,
-        roles: s.roles.map((r) => r.role_code),
+        roles: s.roles.map(
+          (r): TemplateRoleWrite => ({
+            role_code: r.role_code,
+            membres_suggeres_ids: r.membres_suggeres.map((m) => m.membre_id),
+          }),
+        ),
       }))
+      if (tpl.ministere_id) {
+        try {
+          membresDisponibles.value = await repo.getMembersByMinistere(tpl.ministere_id)
+        } catch {
+          membresDisponibles.value = []
+        }
+      }
     }
   } catch {
     loadError.value = 'Impossible de charger ce template.'
@@ -73,11 +92,27 @@ function moveSlot(index: number, direction: 'up' | 'down') {
 }
 
 function addRole(slot: SlotForm) {
-  slot.roles.push('')
+  slot.roles.push({ role_code: '', membres_suggeres_ids: [] })
 }
 
 function removeRole(slot: SlotForm, rIdx: number) {
   slot.roles.splice(rIdx, 1)
+}
+
+function addSuggestedMember(role: TemplateRoleWrite, membreId: string) {
+  if (!role.membres_suggeres_ids.includes(membreId)) {
+    role.membres_suggeres_ids.push(membreId)
+  }
+}
+
+function removeSuggestedMember(role: TemplateRoleWrite, membreId: string) {
+  const idx = role.membres_suggeres_ids.indexOf(membreId)
+  if (idx !== -1) role.membres_suggeres_ids.splice(idx, 1)
+}
+
+function membreLabel(id: string): string {
+  const m = membresDisponibles.value.find((x) => x.id === id)
+  return m ? `${m.prenom} ${m.nom}` : id
 }
 
 async function handleSave() {
@@ -91,7 +126,7 @@ async function handleSave() {
         offset_debut_minutes: s.offset_debut_minutes,
         offset_fin_minutes: s.offset_fin_minutes,
         nb_personnes_requis: s.nb_personnes_requis,
-        roles: s.roles.filter((r) => r.trim() !== ''),
+        roles: s.roles.filter((r) => r.role_code.trim() !== ''),
       })),
     })
     await navigateTo('/planning/templates')
@@ -273,8 +308,8 @@ async function handleSave() {
             </div>
 
             <!-- Rôles -->
-            <div class="mt-3">
-              <div class="mb-1 flex items-center justify-between">
+            <div class="mt-3 space-y-3">
+              <div class="flex items-center justify-between">
                 <label class="text-xs font-medium text-slate-600">Rôles requis</label>
                 <button
                   type="button"
@@ -284,25 +319,79 @@ async function handleSave() {
                   + Ajouter
                 </button>
               </div>
-              <div class="flex flex-wrap gap-2">
-                <div v-for="(_, rIdx) in slot.roles" :key="rIdx" class="flex items-center gap-1">
+
+              <p v-if="slot.roles.length === 0" class="text-xs text-slate-400 italic">Aucun rôle</p>
+
+              <div
+                v-for="(role, rIdx) in slot.roles"
+                :key="rIdx"
+                class="rounded-md border border-slate-200 bg-white p-3"
+              >
+                <!-- Code rôle + supprimer -->
+                <div class="mb-2 flex items-center gap-2">
                   <input
-                    v-model="slot.roles[rIdx]"
+                    v-model="role.role_code"
                     type="text"
-                    class="w-28 rounded border border-slate-300 px-2 py-1 text-xs uppercase outline-none focus:border-blue-400"
+                    class="w-32 rounded border border-slate-300 px-2 py-1 text-xs uppercase outline-none focus:border-blue-400"
                     placeholder="ROLE_CODE"
                   />
                   <button
                     type="button"
-                    class="text-slate-400 hover:text-red-500"
+                    class="ml-auto text-slate-400 hover:text-red-500"
                     @click="removeRole(slot, rIdx)"
                   >
                     <Trash2 class="size-3.5" />
                   </button>
                 </div>
-                <span v-if="slot.roles.length === 0" class="text-xs text-slate-400 italic">
-                  Aucun rôle
-                </span>
+
+                <!-- Membres suggérés -->
+                <div class="space-y-1.5">
+                  <p class="text-xs font-medium text-slate-500">Membres suggérés</p>
+
+                  <!-- Tags membres déjà ajoutés -->
+                  <div v-if="role.membres_suggeres_ids.length > 0" class="flex flex-wrap gap-1">
+                    <span
+                      v-for="membreId in role.membres_suggeres_ids"
+                      :key="membreId"
+                      class="flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800"
+                    >
+                      {{ membreLabel(membreId) }}
+                      <button
+                        type="button"
+                        class="text-blue-500 hover:text-blue-800"
+                        @click="removeSuggestedMember(role, membreId)"
+                      >
+                        ×
+                      </button>
+                    </span>
+                  </div>
+
+                  <!-- Select pour ajouter un membre -->
+                  <select
+                    v-if="membresDisponibles.length > 0"
+                    class="w-full rounded border border-slate-300 px-2 py-1 text-xs text-slate-700 outline-none focus:border-blue-400"
+                    @change="
+                      (e) => {
+                        const val = (e.target as HTMLSelectElement).value
+                        if (val) {
+                          addSuggestedMember(role, val)
+                          ;(e.target as HTMLSelectElement).value = ''
+                        }
+                      }
+                    "
+                  >
+                    <option value="">— Ajouter un membre —</option>
+                    <option
+                      v-for="m in membresDisponibles.filter(
+                        (x) => !role.membres_suggeres_ids.includes(x.id),
+                      )"
+                      :key="m.id"
+                      :value="m.id"
+                    >
+                      {{ m.prenom }} {{ m.nom }}
+                    </option>
+                  </select>
+                </div>
               </div>
             </div>
           </div>

--- a/frontend/layers/planning/app/repositories/PlanningRepository.ts
+++ b/frontend/layers/planning/app/repositories/PlanningRepository.ts
@@ -1,6 +1,7 @@
 import { BaseRepository } from '~~/layers/base/app/repositories/BaseRepository'
 import type { MinistereSimple } from '~~/layers/base/types/ministere'
 import type {
+  ApplyTemplateResult,
   CampusFilterParams,
   CampusTeamRead,
   MembreSimple,
@@ -165,5 +166,14 @@ export class PlanningRepository extends BaseRepository {
     return this.unwrap<PlanningTemplateListItem>(`/planning-templates/${id}/duplicate`, {
       method: 'POST',
     })
+  }
+
+  // ── US-96 : application d'un template sur un planning ───────────────────
+
+  async applyTemplate(templateId: string, planningId: string): Promise<ApplyTemplateResult> {
+    return this.unwrap<ApplyTemplateResult>(
+      `/planning-templates/${templateId}/apply/${planningId}`,
+      { method: 'POST' },
+    )
   }
 }

--- a/frontend/layers/planning/app/types/planning.types.ts
+++ b/frontend/layers/planning/app/types/planning.types.ts
@@ -248,6 +248,7 @@ export interface MembreSimple {
   prenom: string
   email?: string | null
   actif: boolean
+  roles: string[] // role_codes depuis MembreSimpleWithRoles
 }
 
 /** Rôle de compétence pour le select affectation */
@@ -282,9 +283,43 @@ export interface CampusTeamRead {
 // 7. PLANNING TEMPLATES — US-01 / US-95
 // ============================================================
 
+export interface TemplateRoleMembreRead {
+  id: string
+  membre_id: string
+  membre_nom: string
+  membre_username: string
+}
+
+export interface TemplateRoleWrite {
+  role_code: string
+  membres_suggeres_ids: string[]
+}
+
+export interface WarningIndispo {
+  membre_id: string
+  membre_nom: string
+  creneau_nom: string
+  role_code: string
+}
+
+export interface WarningMembreIgnore {
+  membre_id: string
+  membre_nom: string
+  role_code: string
+  raison: 'hors_ministere' | 'role_manquant' | 'introuvable'
+}
+
+export interface ApplyTemplateResult {
+  planning_id: string
+  affectations_creees: number
+  avertissements_indispo: WarningIndispo[]
+  membres_ignores: WarningMembreIgnore[]
+}
+
 export interface PlanningTemplateRoleRead {
   id: string
   role_code: string
+  membres_suggeres: TemplateRoleMembreRead[]
 }
 
 export interface PlanningTemplateSlotRead {
@@ -343,7 +378,7 @@ export interface PlanningTemplateSlotWrite {
   offset_debut_minutes: number
   offset_fin_minutes: number
   nb_personnes_requis: number
-  roles: string[]
+  roles: TemplateRoleWrite[]
 }
 
 export interface PlanningTemplateFullUpdate {


### PR DESCRIPTION


Backend
- Nouvelle table t_planning_template_role_membre (migration f15f3d7ac637) avec FK CASCADE vers t_planning_template_role et t_utilisateur
- apply_to_planning() retourne ApplyTemplateResult avec avertissements indisponibilité et membres ignorés (hors_ministere / introuvable)
- Helpers privés : _apply_membre_suggere, _check_membre_eligibilite, _check_indisponibilite — découpage pylint-safe
- GET /membres/by-ministere/{id} retourne désormais roles: list[str] (role_codes depuis t_membre_role) via MembreSimpleWithRoles
- selectinload complet : slots → roles → membres_suggeres → membre
- Seed : membres_suggeres_ids sur 2 rôles des templates seedés

Frontend
- usePlanningForm : injection de slot.affectations depuis membres_suggeres au moment de l'application du template (pré-remplissage avant save)
- TemplateEditDrawer : sélecteur de rôle en liste déroulante libellé seul (plus de saisie libre du role_code) + validation bloquante compétence avec roleErrors indexé par sIdx-rIdx + mention "(hors compétence)" dans les options + alerte inline AlertTriangle
- PlanningFormView : badges orange (indisponibilité) et gris (ignorés) post-application template
- AppDrawer : fades de défilement top/bottom conditionnels (showTopFade / showBottomFade via onScroll) — pointer-events-none, s'applique à tous les drawers sans modification côté consommateur